### PR TITLE
Refactor image handling to use astro-image-placeholder package

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -3,6 +3,7 @@ import { loadEnv } from "vite";
 import tailwindcss from "@tailwindcss/vite";
 import sitemap from "@astrojs/sitemap";
 import { blogApiMiyamoToday } from "@miyamo2/astro-loader-blogapi-miyamo-today";
+import { imagePlaceholderService } from "@miyamo2/astro-image-placeholder";
 import algoliaIndex from "./integrations/algolia-index";
 
 // `.env` files are not loaded into process.env while the config itself is being
@@ -60,6 +61,10 @@ export default defineConfig({
     },
   },
   image: {
+    // adds the blurred placeholder to every getImage() result as
+    // `data-placeholder`, and caches remote image metadata under
+    // .cache/remote-image-meta (kept by the CI cache step)
+    service: imagePlaceholderService,
     // article thumbnails / body images / GitHub avatar are all remote
     remotePatterns: [{ protocol: "https" }, { protocol: "http" }],
   },

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "dependencies": {
     "@formkit/tempo": "^0.1.2",
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
+    "@miyamo2/astro-image-placeholder": "https://registry.npmjs.org/@miyamo2/astro-image-placeholder/-/astro-image-placeholder-0.1.0.tgz",
     "@miyamo2/astro-loader-blogapi-miyamo-today": "^0.2.0",
     "@miyamo2/astro-recommend-article": "https://registry.npmjs.org/@miyamo2/astro-recommend-article/-/astro-recommend-article-0.1.0.tgz",
     "algoliasearch": "^5.56.0",

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -2,7 +2,9 @@ import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { getCollection, type CollectionEntry } from "astro:content";
 import { excerptOf, renderMarkdown, type ArticleHeading } from "./markdown";
-import { buildCollectionImage, remoteImagesTransform, type RemoteImageData } from "./images";
+import { remarkImagePlaceholder } from "@miyamo2/astro-image-placeholder";
+import { buildCollectionImage, type RemoteImageData } from "./images";
+import { renderRemoteImage } from "./remote-image-render";
 import { PER_PAGE, siteMetadata } from "./site";
 
 interface TagVM {
@@ -127,7 +129,9 @@ const renderAll = async (entries: BlogEntry[]): Promise<Map<string, RenderedArti
     while (index < entries.length) {
       const entry = entries[index++];
       const [markdown, cardImage, detailImage, recommendImage] = await Promise.all([
-        renderMarkdown(entry.body ?? "", [remoteImagesTransform()]),
+        renderMarkdown(entry.body ?? "", [
+          remarkImagePlaceholder({ width: 800, render: renderRemoteImage }),
+        ]),
         buildCollectionImage(entry.data.thumbnail),
         buildCollectionImage(entry.data.thumbnail, { width: 1000, height: 500 }),
         buildCollectionImage(entry.data.thumbnail, { width: 840, height: 420 }),

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -1,11 +1,6 @@
 import { getImage } from "astro:assets";
-import { visit } from "unist-util-visit";
-import { createHash } from "node:crypto";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
-import path from "node:path";
-import type { Root, Image as MdastImage } from "mdast";
+import { getImagePlaceholder, getRemoteImageSize } from "@miyamo2/astro-image-placeholder";
 import type { ImageMetadata } from "astro";
-import type { MdastTransform } from "./markdown";
 
 export interface RemoteImageData {
   src: string;
@@ -17,81 +12,6 @@ export interface RemoteImageData {
   /** base64 data url used as blurred placeholder (like gatsby's BLURRED placeholder) */
   placeholder?: string;
 }
-
-interface RemoteImageInfo {
-  width: number;
-  height: number;
-  placeholder?: string;
-}
-
-const CACHE_DIR = path.join(process.cwd(), ".cache", "remote-image-meta");
-
-const infoCache = new Map<string, Promise<RemoteImageInfo | undefined>>();
-
-// keep the number of parallel remote fetches reasonable
-let inflight = 0;
-const queue: (() => void)[] = [];
-const withLimit = async <T>(fn: () => Promise<T>): Promise<T> => {
-  if (inflight >= 8) {
-    await new Promise<void>((resolve) => queue.push(resolve));
-  }
-  inflight++;
-  try {
-    return await fn();
-  } finally {
-    inflight--;
-    queue.shift()?.();
-  }
-};
-
-const fetchRemoteImageInfo = (url: string): Promise<RemoteImageInfo | undefined> => {
-  const cached = infoCache.get(url);
-  if (cached) {
-    return cached;
-  }
-  const promise = (async (): Promise<RemoteImageInfo | undefined> => {
-    const cacheKey = createHash("sha256").update(url).digest("hex");
-    const cacheFile = path.join(CACHE_DIR, `${cacheKey}.json`);
-    try {
-      const fromDisk = JSON.parse(await readFile(cacheFile, "utf-8")) as RemoteImageInfo;
-      return fromDisk;
-    } catch {
-      // cache miss
-    }
-    try {
-      return await withLimit(async () => {
-        const res = await fetch(url);
-        if (!res.ok) {
-          throw new Error(`failed to fetch image: ${url} (${res.status})`);
-        }
-        const buffer = Buffer.from(await res.arrayBuffer());
-        const { default: sharp } = await import("sharp");
-        const image = sharp(buffer);
-        const metadata = await image.metadata();
-        const width = metadata.width ?? 0;
-        const height = metadata.height ?? 0;
-        const placeholderBuffer = await image
-          .clone()
-          .resize({ width: 20 })
-          .webp({ quality: 50 })
-          .toBuffer();
-        const info: RemoteImageInfo = {
-          width,
-          height,
-          placeholder: `data:image/webp;base64,${placeholderBuffer.toString("base64")}`,
-        };
-        await mkdir(CACHE_DIR, { recursive: true });
-        await writeFile(cacheFile, JSON.stringify(info));
-        return info;
-      });
-    } catch (e) {
-      console.warn(`[images] ${String(e)}`);
-      return undefined;
-    }
-  })();
-  infoCache.set(url, promise);
-  return promise;
-};
 
 export interface BuildRemoteImageOptions {
   /** target width. omitted -> constrained to natural size (max 800px) */
@@ -115,9 +35,23 @@ const srcsetWidths = (targetWidth: number, sourceWidth: number): number[] => {
 const sizesFor = (targetWidth: number): string =>
   `(min-width: ${targetWidth}px) ${targetWidth}px, 100vw`;
 
+const targetSize = (
+  natural: { width: number; height: number },
+  options: BuildRemoteImageOptions
+): { width: number; height: number } => {
+  if (options.width && options.height) {
+    return { width: options.width, height: options.height };
+  }
+  const width = Math.min(options.width ?? 800, natural.width);
+  return { width, height: Math.round((width * natural.height) / natural.width) };
+};
+
 /**
  * Builds an optimized (webp) remote image via astro:assets, replacing
  * gatsby-plugin-image's gatsbyImageData.
+ *
+ * The blurred placeholder comes back on the `getImage()` result, attached by
+ * the image service configured in astro.config.ts.
  */
 export const buildRemoteImage = async (
   url: string | undefined | null,
@@ -126,30 +60,20 @@ export const buildRemoteImage = async (
   if (!url) {
     return null;
   }
-  const info = await fetchRemoteImageInfo(url);
-  if (!info || info.width === 0 || info.height === 0) {
+  // srcset candidates need the natural width, and that has to be known before
+  // getImage() runs; this reads the same cache the image service does
+  const natural = await getRemoteImageSize(url);
+  if (!natural) {
     return null;
   }
-
-  let targetWidth: number;
-  let targetHeight: number;
-  if (options.width && options.height) {
-    targetWidth = options.width;
-    targetHeight = options.height;
-  } else if (options.width) {
-    targetWidth = Math.min(options.width, info.width);
-    targetHeight = Math.round((targetWidth * info.height) / info.width);
-  } else {
-    targetWidth = Math.min(800, info.width);
-    targetHeight = Math.round((targetWidth * info.height) / info.width);
-  }
+  const { width, height } = targetSize(natural, options);
 
   try {
     const result = await getImage({
       src: url,
-      width: targetWidth,
-      height: targetHeight,
-      widths: srcsetWidths(targetWidth, info.width),
+      width,
+      height,
+      widths: srcsetWidths(width, natural.width),
       format: "webp",
       quality: 100,
       ...(options.width && options.height ? { fit: "cover" as const } : {}),
@@ -158,57 +82,32 @@ export const buildRemoteImage = async (
     return {
       src: result.src,
       srcSet,
-      sizes: srcSet ? sizesFor(targetWidth) : undefined,
-      width: targetWidth,
-      height: targetHeight,
-      placeholder: info.placeholder,
+      sizes: srcSet ? sizesFor(width) : undefined,
+      width,
+      height,
+      placeholder: result.attributes["data-placeholder"] as string | undefined,
     };
   } catch (e) {
     console.warn(`[images] failed to optimize ${url}: ${String(e)}`);
     return {
       src: url,
-      width: targetWidth,
-      height: targetHeight,
-      placeholder: info.placeholder,
+      width,
+      height,
+      placeholder: await getImagePlaceholder(url),
     };
   }
 };
 
 // ---- local images (content collection thumbnails) ---------------------------
 
-const localPlaceholderCache = new Map<string, Promise<string | undefined>>();
-
-const localImagePlaceholder = (meta: ImageMetadata): Promise<string | undefined> => {
-  const fsPath = (meta as ImageMetadata & { fsPath?: string }).fsPath;
-  if (!fsPath) {
-    return Promise.resolve(undefined);
-  }
-  const cached = localPlaceholderCache.get(fsPath);
-  if (cached) {
-    return cached;
-  }
-  const promise = (async (): Promise<string | undefined> => {
-    try {
-      const buffer = await readFile(fsPath);
-      const { default: sharp } = await import("sharp");
-      const placeholderBuffer = await sharp(buffer)
-        .resize({ width: 20 })
-        .webp({ quality: 50 })
-        .toBuffer();
-      return `data:image/webp;base64,${placeholderBuffer.toString("base64")}`;
-    } catch (e) {
-      console.warn(`[images] failed to build placeholder for ${fsPath}: ${String(e)}`);
-      return undefined;
-    }
-  })();
-  localPlaceholderCache.set(fsPath, promise);
-  return promise;
-};
-
 /**
  * Builds an optimized (webp) image from a local content-collection image
  * (thumbnails downloaded by @miyamo2/astro-loader-blogapi-miyamo-today),
  * producing the same RemoteImageData shape as buildRemoteImage.
+ *
+ * Unlike the remote case the placeholder is asked for explicitly: astro
+ * replaces `src` with a structuredClone of the ImageMetadata before the image
+ * service sees it, and `fsPath` does not survive the clone.
  */
 export const buildCollectionImage = async (
   meta: ImageMetadata | undefined | null,
@@ -217,27 +116,15 @@ export const buildCollectionImage = async (
   if (!meta || meta.width === 0 || meta.height === 0) {
     return null;
   }
+  const { width, height } = targetSize(meta, options);
+  const placeholder = await getImagePlaceholder(meta);
 
-  let targetWidth: number;
-  let targetHeight: number;
-  if (options.width && options.height) {
-    targetWidth = options.width;
-    targetHeight = options.height;
-  } else if (options.width) {
-    targetWidth = Math.min(options.width, meta.width);
-    targetHeight = Math.round((targetWidth * meta.height) / meta.width);
-  } else {
-    targetWidth = Math.min(800, meta.width);
-    targetHeight = Math.round((targetWidth * meta.height) / meta.width);
-  }
-
-  const placeholder = await localImagePlaceholder(meta);
   try {
     const result = await getImage({
       src: meta,
-      width: targetWidth,
-      height: targetHeight,
-      widths: srcsetWidths(targetWidth, meta.width),
+      width,
+      height,
+      widths: srcsetWidths(width, meta.width),
       format: "webp",
       quality: 100,
       ...(options.width && options.height ? { fit: "cover" as const } : {}),
@@ -246,85 +133,18 @@ export const buildCollectionImage = async (
     return {
       src: result.src,
       srcSet,
-      sizes: srcSet ? sizesFor(targetWidth) : undefined,
-      width: targetWidth,
-      height: targetHeight,
+      sizes: srcSet ? sizesFor(width) : undefined,
+      width,
+      height,
       placeholder,
     };
   } catch (e) {
     console.warn(`[images] failed to optimize ${meta.src}: ${String(e)}`);
     return {
       src: meta.src,
-      width: targetWidth,
-      height: targetHeight,
+      width,
+      height,
       placeholder,
     };
   }
-};
-
-const escapeHtml = (value: string): string =>
-  value.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-
-/**
- * Replaces remote images in the article body with the same markup as
- * gatsby-remark-images-remote (max-width 800, webp, blurred placeholder).
- */
-export const remoteImagesTransform = (): MdastTransform => {
-  return async (tree: Root) => {
-    const targets: { node: MdastImage }[] = [];
-    visit(tree, "image", (node: MdastImage) => {
-      if (!node.url || !/^https?:\/\//.test(node.url)) {
-        return;
-      }
-      targets.push({ node });
-    });
-
-    await Promise.all(
-      targets.map(async ({ node }) => {
-        const image = await buildRemoteImage(node.url);
-        if (!image) {
-          return;
-        }
-        const alt = escapeHtml(node.alt ?? "");
-        const title = escapeHtml(node.title ?? "");
-        const ratio = (image.height / image.width) * 100;
-        const placeholderStyle = image.placeholder
-          ? `background-image: url('${image.placeholder}'); background-size: cover;`
-          : "";
-        const html = `
-  <span
-    class="resp-image-wrapper"
-    style="position: relative; display: block; margin-left: auto; margin-right: auto; max-width: ${image.width}px;"
-  >
-    <a
-      class="resp-image-link"
-      href="${escapeHtml(node.url)}"
-      style="display: block"
-      target="_blank"
-      rel="noopener"
-    >
-      <span
-        class="resp-image-background-image"
-        style="padding-bottom: ${ratio}%; position: relative; bottom: 0; left: 0; ${placeholderStyle} display: block;"
-      ></span>
-      <img
-        class="resp-image-image"
-        alt="${alt}"
-        title="${title}"
-        src="${image.src}"
-        ${image.srcSet ? `srcset="${image.srcSet}"` : ""}
-        sizes="(max-width: ${image.width}px) 100vw, ${image.width}px"
-        style="width: 100%; height: 100%; margin: 0; vertical-align: middle; position: absolute; top: 0; left: 0;"
-        loading="lazy"
-        decoding="async"
-      />
-    </a>
-  </span>`;
-        const replacement = node as unknown as { type: string; value: string; children?: unknown };
-        replacement.type = "html";
-        replacement.value = html;
-        delete replacement.children;
-      })
-    );
-  };
 };

--- a/src/lib/remote-image-render.ts
+++ b/src/lib/remote-image-render.ts
@@ -1,0 +1,51 @@
+import type { ImagePlaceholderRenderContext } from "@miyamo2/astro-image-placeholder";
+
+const escapeHtml = (value: string): string =>
+  value.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+/**
+ * Markup for a remote image in the article body, matching what
+ * gatsby-remark-images-remote produced (max-width 800, webp, blurred
+ * placeholder behind a lazily loaded img).
+ *
+ * Handed to `remarkImagePlaceholder` as its `render` callback — fetching,
+ * placeholder generation and node replacement live in the package; this is the
+ * only part that is specific to this site's CSS.
+ */
+export const renderRemoteImage = (image: ImagePlaceholderRenderContext): string => {
+  const alt = escapeHtml(image.alt ?? "");
+  const title = escapeHtml(image.title ?? "");
+  const ratio = (image.height / image.width) * 100;
+  const placeholderStyle = image.placeholder
+    ? `background-image: url('${image.placeholder}'); background-size: cover;`
+    : "";
+  return `
+  <span
+    class="resp-image-wrapper"
+    style="position: relative; display: block; margin-left: auto; margin-right: auto; max-width: ${image.width}px;"
+  >
+    <a
+      class="resp-image-link"
+      href="${escapeHtml(image.url)}"
+      style="display: block"
+      target="_blank"
+      rel="noopener"
+    >
+      <span
+        class="resp-image-background-image"
+        style="padding-bottom: ${ratio}%; position: relative; bottom: 0; left: 0; ${placeholderStyle} display: block;"
+      ></span>
+      <img
+        class="resp-image-image"
+        alt="${alt}"
+        title="${title}"
+        src="${image.src}"
+        ${image.srcSet ? `srcset="${image.srcSet}"` : ""}
+        sizes="(max-width: ${image.width}px) 100vw, ${image.width}px"
+        style="width: 100%; height: 100%; margin: 0; vertical-align: middle; position: absolute; top: 0; left: 0;"
+        loading="lazy"
+        decoding="async"
+      />
+    </a>
+  </span>`;
+};


### PR DESCRIPTION
## Summary
Extracted image placeholder generation and remote image metadata caching logic into a dedicated `@miyamo2/astro-image-placeholder` package, significantly simplifying the image handling code while maintaining the same functionality.

## Key Changes

- **Removed custom implementations**: Deleted ~150 lines of custom code for:
  - Remote image metadata fetching and caching
  - Placeholder generation for both remote and local images
  - Request concurrency limiting
  - Markdown AST transformation for remote images

- **Integrated astro-image-placeholder package**: 
  - Added `imagePlaceholderService` to `astro.config.ts` image configuration
  - Imported `getImagePlaceholder` and `getRemoteImageSize` utilities
  - Imported `remarkImagePlaceholder` remark plugin for markdown processing

- **Extracted site-specific rendering logic**:
  - Created new `src/lib/remote-image-render.ts` with `renderRemoteImage()` function
  - This function encapsulates the HTML markup generation specific to this site's CSS classes and styling
  - Passed as a `render` callback to the `remarkImagePlaceholder` plugin

- **Simplified image building functions**:
  - `buildRemoteImage()` now delegates placeholder generation to the image service (retrieved via `result.attributes["data-placeholder"]`)
  - `buildCollectionImage()` explicitly calls `getImagePlaceholder()` since local images don't go through the image service
  - Extracted common target size calculation into `targetSize()` helper function

- **Updated markdown rendering**:
  - Replaced `remoteImagesTransform()` with `remarkImagePlaceholder()` plugin in `src/lib/content.ts`
  - Plugin handles image detection, fetching, and node replacement; site provides only the rendering function

## Implementation Details

The refactoring maintains backward compatibility with the existing image output format while delegating infrastructure concerns (caching, fetching, placeholder generation) to the dedicated package. The image service configured in `astro.config.ts` now handles placeholder generation for remote images, making it available to `getImage()` results automatically.

https://claude.ai/code/session_01U786weUb3tyjuY7yjZAtVT