### PR TITLE
perf: defer the Buy Me a Coffee widget script

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -133,8 +133,12 @@ document.addEventListener("astro:page-load", initBmcCloseButton);`;
     {/* data-cfasync="false" excludes this tag from Cloudflare Rocket Loader, which
       rewrites the script's type attribute and breaks the widget's use of
       document.currentScript to read its own data-* attributes */}
+    {/* defer keeps the third-party widget from blocking parsing and the load event;
+      document.currentScript is still set while a deferred classic script runs, so
+      the widget can read its data-* attributes as before */}
     <script
       is:inline
+      defer
       data-cfasync="false"
       data-name="BMC-Widget"
       src="https://cdnjs.buymeacoffee.com/1.0.0/widget.prod.min.js"


### PR DESCRIPTION
## 概要

Buy Me a Coffee ウィジェットの `<script>` に `defer` を追加します。

サイト上のスクリプトを棚卸ししたところ、`async` / `defer` のない外部 classic script はこれだけでした（gtag は `async` 済み、Astro のコンポーネントスクリプトは `type="module"` で元から defer 相当、giscus は動的挿入 + `async` + `data-loading="lazy"`）。`</body>` 直前とはいえ現状はパースを止め、クロスオリジンのバンドルと iframe の取得が終わるまで `load` イベントも遅らせています。

## 互換性

- `document.currentScript` は **deferred な classic script の実行中もセットされる**ため、ウィジェットが自分の `data-*` 属性を読む挙動は維持されます。ブラウザ（Chromium, mobile viewport）で `defer` + 外部スクリプトの `document.currentScript` と `data-id` の取得を実測して確認済みです。
  - これは `data-cfasync="false"` を外せるという意味ではありません。Cloudflare Rocket Loader は `type` 属性ごと書き換えるため引き続き非互換で、既存の除外指定はそのまま残しています。
- deferred script は `DOMContentLoaded` より前に実行されるため、`bmcCloseButtonScript` が待っている順序関係も変わりません（実測時の `document.readyState` は `interactive`）。

## 変更点

- `src/layouts/Layout.astro` — BMC ウィジェットの script タグに `defer` を追加し、理由をコメントで明記

## 検討したが見送った案

`requestIdleCallback` でスクリプトタグを動的注入し、ロード完了後まで丸ごと後回しにする案も実装・計測しました（CLS は前後とも 0、動的挿入でも `document.currentScript` は機能、閉じるボタンの配線も維持できることを確認）。ただし `initBmcCloseButton` が `DOMContentLoaded` に依存できなくなり `MutationObserver` での監視が必要になるなど可動部が増えるため、このPRでは `defer` のみに留めています。