### PR TITLE
feat: skip view transition when leaving an article for a list page

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -99,6 +99,9 @@ document.addEventListener("astro:page-load", initBmcCloseButton);`;
     <ClientRouter />
     <script is:inline set:html={copyToClipboardScript} />
     <script is:inline set:html={bmcPersistScript} />
+    <script>
+      import "../lib/viewTransition.client";
+    </script>
   </head>
   <body>
     <div id="app-root">

--- a/src/lib/viewTransition.client.ts
+++ b/src/lib/viewTransition.client.ts
@@ -1,0 +1,23 @@
+/** Client-side counterpart of viewTransition.ts, loaded once from Layout.astro. */
+
+/** `/articles/<id>` */
+const isArticleDetail = (url: URL): boolean => /^\/articles\/[^/]+\/?$/.test(url.pathname);
+
+/** every page built out of ArticleCard: `/`, `/pages/<n>`, `/tags/<tag>`, `/tags/<tag>/<n>` */
+const isArticleList = (url: URL): boolean =>
+  url.pathname === "/" ||
+  /^\/pages\/[^/]+\/?$/.test(url.pathname) ||
+  /^\/tags\/[^/]+(?:\/[^/]+)?\/?$/.test(url.pathname);
+
+/* Leaving an article for a list page by link (header logo, nav, a tag, search)
+   plays the card morph in reverse, but the list is rendered from the top while
+   the matching card usually sits far below the fold -- the article snapshot
+   flies off to an arbitrary spot, or to a card that isn't even on that page.
+   Browser back keeps the morph: there the list is restored at the scroll
+   position the card was clicked from, so it lands exactly where it started. */
+document.addEventListener("astro:before-swap", (event) => {
+  if (event.navigationType === "traverse") return;
+  if (!isArticleDetail(event.from) || !isArticleList(event.to)) return;
+  // skips the animation only; the DOM swap still happens
+  event.viewTransition?.skipTransition();
+});


### PR DESCRIPTION
Clicking away from an article detail page to a list page (header logo,
nav, a tag, a search hit) played the card morph in reverse, but the list
renders scrolled to the top while the matching card usually sits below
the fold -- or isn't on that page at all -- so the article snapshot flew
off to an arbitrary spot.

Skip the transition for that navigation unless it is a history traversal:
on browser back the list is restored at the scroll position the card was
clicked from, where the morph lands exactly where it started.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01U2ApypGX59Zmoo1tJcF9qA