### PR TITLE
perf: encode images at webp quality 80 instead of 100

### DIFF
--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -35,6 +35,14 @@ const srcsetWidths = (targetWidth: number, sourceWidth: number): number[] => {
 const sizesFor = (targetWidth: number): string =>
   `(min-width: ${targetWidth}px) ${targetWidth}px, 100vw`;
 
+// webp encode quality. 100 disables webp's perceptual quantization almost
+// entirely and made every variant 3-4x larger than it needs to be (PageSpeed
+// Insights' "increasing the image compression factor could improve this
+// image's download size"). 80 is both sharp's and astro's own default
+// (`quality: "high"` maps to 80 for webp) and is visually indistinguishable
+// here at the sizes we serve.
+const IMAGE_QUALITY = 80;
+
 /**
  * Builds an optimized (webp) remote image via astro:assets, replacing
  * gatsby-plugin-image's gatsbyImageData. Dimension probing and the blur
@@ -74,7 +82,7 @@ export const buildRemoteImage = async (
       height: targetHeight,
       widths: srcsetWidths(targetWidth, size.width),
       format: "webp",
-      quality: 100,
+      quality: IMAGE_QUALITY,
       ...(options.width && options.height ? { fit: "cover" as const } : {}),
     });
     const srcSet = result.srcSet.attribute !== "" ? result.srcSet.attribute : undefined;
@@ -133,7 +141,7 @@ export const buildCollectionImage = async (
       height: targetHeight,
       widths: srcsetWidths(targetWidth, meta.width),
       format: "webp",
-      quality: 100,
+      quality: IMAGE_QUALITY,
       ...(options.width && options.height ? { fit: "cover" as const } : {}),
     });
     const srcSet = result.srcSet.attribute !== "" ? result.srcSet.attribute : undefined;


### PR DESCRIPTION
Every getImage() call in src/lib/images.ts asked for `quality: 100`, which
all but disables webp's perceptual quantization: each thumbnail variant was
3-4x larger than it needed to be, which is what PageSpeed Insights reports
as "increasing the image compression factor could improve this image's
download size" on both mobile and desktop.

Encode at 80 instead -- sharp's and astro's own default for webp. Measured
with the same sharp pipeline astro's image service uses, the card and
detail thumbnail variants shrink by 70-80% (e.g. the 1120x440 card 2x
variant: 131KB -> 34KB for a photo, 37KB -> 9KB for a flat graphic) at
39-45 dB PSNR against the quality-100 output, i.e. no visible difference at
the sizes we serve.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011HtueydJdUr4ftPZ9gAcM4