### PR TITLE
perf: preconnect のヒントを実際に使われるオリジンに絞る

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -45,13 +45,17 @@ const gtagInit = `window.dataLayer = window.dataLayer || [];function gtag(){data
 // gatsby-plugin-manifest icon set
 const manifestIconSizes = [48, 72, 96, 144, 192, 256, 384, 512];
 
-// gatsby-plugin-preconnect
+// Origins the page actually requests during load. `crossorigin` is intentionally
+// omitted: it buckets the socket into the anonymous (CORS) connection pool, and
+// every cross-origin subresource here (scripts, stylesheets, images) is fetched
+// in no-cors mode, so a crossorigin preconnect would sit unused. The only
+// CORS-fetched resources are the fonts, and those are same-origin.
 const preconnectDomains = [
+  // Buy Me a Coffee widget loader, then the widget's own assets
+  "https://cdnjs.buymeacoffee.com",
   "https://cdn.buymeacoffee.com",
-  "https://www.reddit.com",
+  // gtag.js (production only, see below)
   "https://www.googletagmanager.com",
-  "https://opengraph.githubassets.com",
-  "https://t3.gstatic.com",
 ];
 ---
 
@@ -108,8 +112,7 @@ const preconnectDomains = [
   crossorigin="anonymous"
 />
 
-{/* gatsby-plugin-preconnect */}
-{preconnectDomains.map((domain) => <link rel="preconnect" href={domain} crossorigin />)}
+{preconnectDomains.map((domain) => <link rel="preconnect" href={domain} />)}
 
 {/* gatsby-plugin-manifest */}
 <link rel="manifest" href="/manifest.webmanifest" />


### PR DESCRIPTION
PageSpeed Insights が preconnect の大半を「未使用」として報告していたため整理した。

- crossorigin を削除。preconnect の crossorigin は匿名 (CORS) コネクション
  プールにソケットを割り当てるが、このページのクロスオリジンのサブリソース
  (スクリプト・スタイルシート・画像) はすべて no-cors で取得されるため、
  ソケットが再利用されず接続が無駄になっていた。CORS で取得されるのは
  フォントだけで、それらは同一オリジンから配信している。
- www.reddit.com / opengraph.githubassets.com / t3.gstatic.com を削除。
  reddit は共有ボタンのリンク先で、読み込み時にリクエストは発生しない。
  残り 2 つは Gatsby 時代の名残でリクエスト自体がない。
- cdnjs.buymeacoffee.com を追加。Buy Me a Coffee ウィジェットのローダーは
  この別オリジンから読み込まれ、そこから cdn.buymeacoffee.com のアセット
  取得が始まる。

これでヒントは推奨上限の 4 つ以下に収まる。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LQJzSiG8D5rYACS2UiLqCQ