### PR TITLE
perf: eagerly fetch above-the-fold images at high priority

### DIFF
--- a/src/components/RemoteImage.astro
+++ b/src/components/RemoteImage.astro
@@ -15,9 +15,29 @@ interface Props {
   style?: string;
   /** fill the parent container instead of capping at the image's own width (e.g. fluid grid cards) */
   fill?: boolean;
+  /**
+   * this image is (or is likely to be) the LCP element: fetch it eagerly at high
+   * priority instead of lazily. `loading="lazy"` hides the image from the preload
+   * scanner, so its request cannot start until the render-blocking CSS has landed
+   * and layout has run -- on a throttled mobile connection that alone pushes LCP
+   * several seconds out. It also drops `decoding="async"`, which would otherwise
+   * let a frame be presented before the LCP candidate has finished decoding.
+   * Only ever set this on above-the-fold images; marking extra ones just steals
+   * bandwidth from the real LCP candidate.
+   */
+  priority?: boolean;
 }
 
-const { image, alt, objectFit, objectPosition, class: className, style, fill } = Astro.props;
+const {
+  image,
+  alt,
+  objectFit,
+  objectPosition,
+  class: className,
+  style,
+  fill,
+  priority = false,
+} = Astro.props;
 
 // transparent svg spacer keeps the intrinsic size, like gatsby-plugin-image's
 // constrained layout, so the wrapper works in auto-sized containers too
@@ -63,8 +83,9 @@ const wrapperStyle = image
         srcset={image.srcSet}
         sizes={image.srcSet ? image.sizes : undefined}
         alt={alt ?? ""}
-        loading="lazy"
-        decoding="async"
+        loading={priority ? "eager" : "lazy"}
+        fetchpriority={priority ? "high" : undefined}
+        decoding={priority ? undefined : "async"}
         style={`position: absolute; top: 0; left: 0; width: 100%; height: 100%; object-fit: ${objectFit ?? "cover"}; object-position: ${objectPosition ?? "center"};`}
       />
     </div>

--- a/src/features/ArticleList/ArticleCard.astro
+++ b/src/features/ArticleList/ArticleCard.astro
@@ -21,9 +21,11 @@ interface Props {
   tags: Tag[];
   imageData: RemoteImageData | null;
   articleExcerpt?: string;
+  /** this card sits above the fold, so its thumbnail is the page's LCP candidate */
+  priority?: boolean;
 }
 
-const { id, title, createdAt, tags, imageData, articleExcerpt } = Astro.props;
+const { id, title, createdAt, tags, imageData, articleExcerpt, priority } = Astro.props;
 
 const formattedCreatedAt = format(new Date(createdAt), "YYYY/MM/DD");
 ---
@@ -44,6 +46,7 @@ const formattedCreatedAt = format(new Date(createdAt), "YYYY/MM/DD");
           objectPosition="center"
           objectFit="cover"
           fill
+          priority={priority}
           class="transform-scaleup-then-hover-img-container h-full w-full"
         />
       )

--- a/src/views/AboutPage.astro
+++ b/src/views/AboutPage.astro
@@ -60,6 +60,7 @@ const socialLinks = [
           alt="GitHubAvatar:miyamo2"
           objectFit="cover"
           class="round-image"
+          priority
         />
       </div>
       <div class="pb-4 [grid-area:name]">

--- a/src/views/ArticleDetailPage.astro
+++ b/src/views/ArticleDetailPage.astro
@@ -56,6 +56,7 @@ const createdAt = format(new Date(data.createdAt ?? ""), "YYYY/MM/DD");
         alt={`ArticleImage:${data.id}`}
         objectFit="cover"
         style={articleHeroTransition(data.id)}
+        priority
       />
     </div>
     <div style="grid-area: lnav" class="hidden h-full self-end lg:block">

--- a/src/views/ArticleListPage.astro
+++ b/src/views/ArticleListPage.astro
@@ -13,7 +13,11 @@ const { data } = Astro.props;
 <main>
   <h1 class="pb-4 text-3xl font-bold">Articles</h1>
   <div class="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-2">
-    {data.cards.map((card) => <ArticleCard {...card} />)}
+    {
+      /* the grid is single-column on mobile, so the first card's thumbnail is
+         the LCP element -- it must not be lazily loaded */
+      data.cards.map((card, i) => <ArticleCard {...card} priority={i === 0} />)
+    }
   </div>
   <div class="pt-6 pb-2">
     <Pager

--- a/src/views/TaggedArticlesPage.astro
+++ b/src/views/TaggedArticlesPage.astro
@@ -13,7 +13,11 @@ const { data } = Astro.props;
 <main>
   <h1 class="pb-4 text-3xl font-bold">#{data.tagName}</h1>
   <div class="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-2">
-    {data.cards.map((card) => <ArticleCard {...card} />)}
+    {
+      /* the grid is single-column on mobile, so the first card's thumbnail is
+         the LCP element -- it must not be lazily loaded */
+      data.cards.map((card, i) => <ArticleCard {...card} priority={i === 0} />)
+    }
   </div>
   <div class="pt-6 pb-2">
     <Pager


### PR DESCRIPTION
PageSpeed Insights reported a 9.8s mobile LCP on the article list, with two
failing LCP audits on the first card's thumbnail: "do not lazily load the LCP
resource" and "fetchpriority=high should be applied".

Every RemoteImage rendered `loading="lazy"`, which hides the image from the
preload scanner: its request cannot even be queued until the render-blocking
CSS has landed and layout has run, so on a throttled mobile connection the LCP
candidate starts downloading seconds after the document does.

Add a `priority` prop that switches the image to `loading="eager"` +
`fetchpriority="high"` and drops `decoding="async"` (which lets a frame be
presented before the LCP candidate has decoded), and set it on the images that
are above the fold: the first article card on the list and tagged-article
pages, the article detail hero, and the about page avatar. Everything else
keeps lazy loading, so the LCP candidate no longer competes with the other 23
thumbnails on the page.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KDh1sfkiSU8UscQixh66P2