### PR TITLE
hotfix(images): download link card images instead of deferring to astro:assets

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,4 +1,6 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig, envField } from "astro/config";
+import type { AstroIntegration } from "astro";
 import { loadEnv } from "vite";
 import tailwindcss from "@tailwindcss/vite";
 import sitemap from "@astrojs/sitemap";
@@ -40,6 +42,34 @@ const serializeRenders = (processor: ReturnType<typeof satteri>): typeof process
         ...renderer,
         render: (content, renderOpts) => limit(() => renderer.render(content, renderOpts)),
       };
+    },
+  };
+};
+
+/**
+ * Publishes the build output / cache directories to `optimizeLinkCardImages`
+ * (src/lib/link-card-images.ts), which downloads the link cards' remote images
+ * itself and stages them in the build output for astro:assets to pick up as
+ * local images. Page rendering runs in its own module graph, so process.env is
+ * the only channel to it; only a real build sets them (`astro dev` has no build
+ * output, and there the images stay as satteri-link-card emitted them).
+ */
+const linkCardImages = (): AstroIntegration => {
+  let enabled = false;
+  return {
+    name: "link-card-images",
+    hooks: {
+      "astro:config:setup": ({ command }) => {
+        enabled = command === "build";
+      },
+      "astro:config:done": ({ config }) => {
+        if (!enabled) {
+          return;
+        }
+        process.env.LINK_CARD_IMAGE_OUT_DIR = fileURLToPath(config.outDir);
+        process.env.LINK_CARD_IMAGE_CACHE_DIR = fileURLToPath(config.cacheDir);
+        process.env.LINK_CARD_IMAGE_ASSETS_DIR = config.build.assets;
+      },
     },
   };
 };
@@ -91,6 +121,7 @@ export default defineConfig({
     ),
   },
   integrations: [
+    linkCardImages(),
     blogApiMiyamoToday({
       url: env.BLOG_API_MIYAMO_TODAY_URL ?? "",
       token: env.BLOG_API_MIYAMO_TODAY_TOKEN ?? "",

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,6 +1,4 @@
-import { fileURLToPath } from "node:url";
 import { defineConfig, envField } from "astro/config";
-import type { AstroIntegration } from "astro";
 import { loadEnv } from "vite";
 import tailwindcss from "@tailwindcss/vite";
 import sitemap from "@astrojs/sitemap";
@@ -10,6 +8,7 @@ import { satteriLinkCard } from "satteri-link-card";
 import { blogApiMiyamoToday } from "@miyamo2/astro-loader-blogapi-miyamo-today";
 import algoliaIndex from "@miyamo2/astro-algolia-index";
 import { imagePlaceholderService } from "@miyamo2/astro-image-placeholder";
+import { remoteImageStaging } from "./integrations/remote-image-staging";
 import {
   headingAnchorPlugin,
   plainTextMdastPlugin,
@@ -42,37 +41,6 @@ const serializeRenders = (processor: ReturnType<typeof satteri>): typeof process
         ...renderer,
         render: (content, renderOpts) => limit(() => renderer.render(content, renderOpts)),
       };
-    },
-  };
-};
-
-/**
- * Publishes the build output / cache / assets directories to
- * src/lib/staged-remote-image.ts, which downloads every remote image (article
- * bodies and link cards alike) itself and stages it in the build output for
- * astro:assets to pick up as a local image -- keeping astro's own
- * image-generation phase, where a failure is fatal, off the network.
- *
- * Page rendering runs in its own module graph, so process.env is the only
- * channel to it. Only a real build sets them: `astro dev` has no build output
- * to stage into, and resolves remote images per request instead.
- */
-const remoteImageStaging = (): AstroIntegration => {
-  let enabled = false;
-  return {
-    name: "remote-image-staging",
-    hooks: {
-      "astro:config:setup": ({ command }) => {
-        enabled = command === "build";
-      },
-      "astro:config:done": ({ config }) => {
-        if (!enabled) {
-          return;
-        }
-        process.env.REMOTE_IMAGE_OUT_DIR = fileURLToPath(config.outDir);
-        process.env.REMOTE_IMAGE_CACHE_DIR = fileURLToPath(config.cacheDir);
-        process.env.REMOTE_IMAGE_ASSETS_DIR = config.build.assets;
-      },
     },
   };
 };

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -47,17 +47,20 @@ const serializeRenders = (processor: ReturnType<typeof satteri>): typeof process
 };
 
 /**
- * Publishes the build output / cache directories to `optimizeLinkCardImages`
- * (src/lib/link-card-images.ts), which downloads the link cards' remote images
- * itself and stages them in the build output for astro:assets to pick up as
- * local images. Page rendering runs in its own module graph, so process.env is
- * the only channel to it; only a real build sets them (`astro dev` has no build
- * output, and there the images stay as satteri-link-card emitted them).
+ * Publishes the build output / cache / assets directories to
+ * src/lib/staged-remote-image.ts, which downloads every remote image (article
+ * bodies and link cards alike) itself and stages it in the build output for
+ * astro:assets to pick up as a local image -- keeping astro's own
+ * image-generation phase, where a failure is fatal, off the network.
+ *
+ * Page rendering runs in its own module graph, so process.env is the only
+ * channel to it. Only a real build sets them: `astro dev` has no build output
+ * to stage into, and resolves remote images per request instead.
  */
-const linkCardImages = (): AstroIntegration => {
+const remoteImageStaging = (): AstroIntegration => {
   let enabled = false;
   return {
-    name: "link-card-images",
+    name: "remote-image-staging",
     hooks: {
       "astro:config:setup": ({ command }) => {
         enabled = command === "build";
@@ -66,9 +69,9 @@ const linkCardImages = (): AstroIntegration => {
         if (!enabled) {
           return;
         }
-        process.env.LINK_CARD_IMAGE_OUT_DIR = fileURLToPath(config.outDir);
-        process.env.LINK_CARD_IMAGE_CACHE_DIR = fileURLToPath(config.cacheDir);
-        process.env.LINK_CARD_IMAGE_ASSETS_DIR = config.build.assets;
+        process.env.REMOTE_IMAGE_OUT_DIR = fileURLToPath(config.outDir);
+        process.env.REMOTE_IMAGE_CACHE_DIR = fileURLToPath(config.cacheDir);
+        process.env.REMOTE_IMAGE_ASSETS_DIR = config.build.assets;
       },
     },
   };
@@ -121,7 +124,7 @@ export default defineConfig({
     ),
   },
   integrations: [
-    linkCardImages(),
+    remoteImageStaging(),
     blogApiMiyamoToday({
       url: env.BLOG_API_MIYAMO_TODAY_URL ?? "",
       token: env.BLOG_API_MIYAMO_TODAY_TOKEN ?? "",

--- a/integrations/remote-image-staging/env.ts
+++ b/integrations/remote-image-staging/env.ts
@@ -1,0 +1,38 @@
+/**
+ * The contract between the `remote-image-staging` integration and
+ * src/lib/staged-remote-image.ts.
+ *
+ * The integration runs while the astro config is evaluated; the code that
+ * stages images runs while pages render. Those are separate module graphs, so
+ * a module-level value cannot be shared between them -- process.env can, and
+ * these accessors keep its keys in one place.
+ */
+
+export interface RemoteImageDirectories {
+  /** build output root; a staged original has to land inside it */
+  outDir: string;
+  /** where downloaded originals are kept between builds */
+  cacheDir: string;
+  /**
+   * Hashed-assets folder, relative to the output root. Originals are staged
+   * there so the variants astro derives from them land next to every other
+   * hashed asset -- the deploy step uploads `dist/_astro` first and as
+   * `immutable` (see .github/workflows/publish.yaml), which is what they are.
+   */
+  assetsDir: string;
+}
+
+export const publishRemoteImageDirectories = (dirs: RemoteImageDirectories): void => {
+  process.env.REMOTE_IMAGE_OUT_DIR = dirs.outDir;
+  process.env.REMOTE_IMAGE_CACHE_DIR = dirs.cacheDir;
+  process.env.REMOTE_IMAGE_ASSETS_DIR = dirs.assetsDir;
+};
+
+/** unset outside `astro build` -- nothing is staged then */
+export const remoteImageOutDir = (): string | undefined =>
+  process.env.REMOTE_IMAGE_OUT_DIR || undefined;
+
+export const remoteImageCacheDir = (): string | undefined =>
+  process.env.REMOTE_IMAGE_CACHE_DIR || undefined;
+
+export const remoteImageAssetsDir = (): string => process.env.REMOTE_IMAGE_ASSETS_DIR || "_astro";

--- a/integrations/remote-image-staging/index.ts
+++ b/integrations/remote-image-staging/index.ts
@@ -1,0 +1,37 @@
+import { fileURLToPath } from "node:url";
+import type { AstroIntegration } from "astro";
+import { publishRemoteImageDirectories } from "./env";
+
+/**
+ * Publishes the build output / cache / assets directories to
+ * src/lib/staged-remote-image.ts, which downloads every remote image (article
+ * bodies and link cards alike) itself and stages it in the build output for
+ * astro:assets to pick up as a local image -- keeping astro's own
+ * image-generation phase, where a failure aborts the whole build, off the
+ * network.
+ *
+ * Only a real build publishes them: `astro dev` has no build output to stage
+ * into and resolves remote images per request instead, where a failure costs
+ * one image rather than the build.
+ */
+export const remoteImageStaging = (): AstroIntegration => {
+  let isBuild = false;
+  return {
+    name: "remote-image-staging",
+    hooks: {
+      "astro:config:setup": ({ command }) => {
+        isBuild = command === "build";
+      },
+      "astro:config:done": ({ config }) => {
+        if (!isBuild) {
+          return;
+        }
+        publishRemoteImageDirectories({
+          outDir: fileURLToPath(config.outDir),
+          cacheDir: fileURLToPath(config.cacheDir),
+          assetsDir: config.build.assets,
+        });
+      },
+    },
+  };
+};

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -5,10 +5,10 @@ import type { MarkdownHeading } from "astro";
 import { excerptOf, type ArticleHeading } from "./markdown";
 import {
   buildCollectionImage,
-  optimizeLinkCardImages,
   replaceRemoteImagePlaceholders,
   type RemoteImageData,
 } from "./images";
+import { optimizeLinkCardImages } from "./link-card-images";
 import { PER_PAGE, siteMetadata } from "./site";
 
 interface TagVM {

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -18,10 +18,6 @@ export interface BuildRemoteImageOptions {
   width?: number;
   /** target height. requires width; crops with fit: cover like gatsbyImageData(width, height) */
   height?: number;
-  /** srcSet width descriptors. omitted -> [target, 2x target] (see srcsetWidths) */
-  widths?: number[];
-  /** sizes attribute paired with the srcSet. omitted -> sizesFor(target) */
-  sizes?: string;
 }
 
 // like gatsby's CONSTRAINED layout: offer up to 2x of the target width (capped
@@ -34,19 +30,6 @@ const srcsetWidths = (targetWidth: number, sourceWidth: number): number[] => {
     widths.push(cap);
   }
   return widths;
-};
-
-// explicit `widths` win over the 1x/2x default, but never upscale past the
-// source (astro happily emits an upscaled variant, which is pure bytes)
-const candidateWidths = (
-  widths: number[] | undefined,
-  targetWidth: number,
-  sourceWidth: number
-): number[] => {
-  if (!widths || widths.length === 0) {
-    return srcsetWidths(targetWidth, sourceWidth);
-  }
-  return [...new Set(widths.map((width) => Math.min(width, sourceWidth)))].sort((a, b) => a - b);
 };
 
 const sizesFor = (targetWidth: number): string =>
@@ -97,7 +80,7 @@ export const buildRemoteImage = async (
       src: url,
       width: targetWidth,
       height: targetHeight,
-      widths: candidateWidths(options.widths, targetWidth, size.width),
+      widths: srcsetWidths(targetWidth, size.width),
       format: "webp",
       quality: IMAGE_QUALITY,
       ...(options.width && options.height ? { fit: "cover" as const } : {}),
@@ -106,7 +89,7 @@ export const buildRemoteImage = async (
     return {
       src: result.src,
       srcSet,
-      sizes: srcSet ? (options.sizes ?? sizesFor(targetWidth)) : undefined,
+      sizes: srcSet ? sizesFor(targetWidth) : undefined,
       width: targetWidth,
       height: targetHeight,
       placeholder: result.attributes["data-placeholder"] as string | undefined,
@@ -156,7 +139,7 @@ export const buildCollectionImage = async (
       src: meta,
       width: targetWidth,
       height: targetHeight,
-      widths: candidateWidths(options.widths, targetWidth, meta.width),
+      widths: srcsetWidths(targetWidth, meta.width),
       format: "webp",
       quality: IMAGE_QUALITY,
       ...(options.width && options.height ? { fit: "cover" as const } : {}),
@@ -165,7 +148,7 @@ export const buildCollectionImage = async (
     return {
       src: result.src,
       srcSet,
-      sizes: srcSet ? (options.sizes ?? sizesFor(targetWidth)) : undefined,
+      sizes: srcSet ? sizesFor(targetWidth) : undefined,
       width: targetWidth,
       height: targetHeight,
       placeholder,
@@ -250,137 +233,15 @@ export const replaceRemoteImagePlaceholders = async (html: string): Promise<stri
   }
   const replacements = await Promise.all(
     matches.map(async (match) => {
-      const { url, alt, title } = JSON.parse(Buffer.from(match[1], "base64").toString("utf-8")) as {
-        url: string;
-        alt: string;
-        title: string;
-      };
+      const { url, alt, title } = JSON.parse(
+        Buffer.from(match[1], "base64").toString("utf-8")
+      ) as { url: string; alt: string; title: string };
       return [match[0], await renderRemoteImageMarkup(url, alt, title)] as const;
     })
   );
   let result = html;
   for (const [placeholder, markup] of replacements) {
     result = result.replace(placeholder, markup);
-  }
-  return result;
-};
-
-// satteri-link-card emits the OGP image / favicon URLs verbatim (its own
-// `imageCache` only self-hosts the original bytes, it never resizes), so a
-// 1200x600 og:image lands in a box that is never wider than ~273 CSS px --
-// PageSpeed Insights' "Improve image delivery". These constants describe that
-// box; see `.satteri-link-card__media` / `__favicon` in styles/vendor.css.
-const LINK_CARD_IMAGE_WIDTH = 280;
-const LINK_CARD_IMAGE_HEIGHT = 140;
-// 448w is the mobile candidate lighthouse asks for (412px viewport, 40vw slot,
-// DPR 1.75); 560w covers the widest desktop box (273px) at DPR 2
-const LINK_CARD_IMAGE_WIDTHS = [160, 280, 448, 560];
-// media box is 40% of the card below 768px and 30% above it; the card itself is
-// the content column, which stops growing at 1400px * 65% (see article-detail.css)
-const LINK_CARD_IMAGE_SIZES = `(min-width: 1200px) ${LINK_CARD_IMAGE_WIDTH}px, (min-width: 768px) 30vw, 40vw`;
-const LINK_CARD_FAVICON_WIDTH = 14;
-
-const LINK_CARD_IMG = /<img\b[^>]*\bclass="satteri-link-card__(image|favicon)"[^>]*>/g;
-const SRC_ATTRIBUTE = /\ssrc="([^"]*)"/;
-
-const decodeHtml = (value: string): string =>
-  value
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    // last: an escaped entity must not be produced by an earlier replacement
-    .replace(/&amp;/g, "&");
-
-/** sets (or adds, keeping the tag's self-closing form) attributes on one tag */
-const withAttributes = (tag: string, attributes: Record<string, string | undefined>): string => {
-  let result = tag;
-  for (const [name, value] of Object.entries(attributes)) {
-    if (value === undefined) {
-      continue;
-    }
-    const attribute = ` ${name}="${value}"`;
-    const existing = new RegExp(`\\s${name}="[^"]*"`);
-    result = existing.test(result)
-      ? result.replace(existing, () => attribute)
-      : result.replace(/\s*\/?>$/, (close) => `${attribute}${close}`);
-  }
-  return result;
-};
-
-// one build fetches/optimizes the same og:image and (especially) the same
-// favicon over and over -- articles link to the same hosts repeatedly
-const linkCardImageCache = new Map<string, Promise<RemoteImageData | null>>();
-
-const linkCardImage = (url: string, kind: "image" | "favicon"): Promise<RemoteImageData | null> => {
-  const key = `${kind}:${url}`;
-  const cached = linkCardImageCache.get(key);
-  if (cached) {
-    return cached;
-  }
-  const pending = buildRemoteImage(
-    url,
-    kind === "image"
-      ? {
-          width: LINK_CARD_IMAGE_WIDTH,
-          height: LINK_CARD_IMAGE_HEIGHT,
-          widths: LINK_CARD_IMAGE_WIDTHS,
-          sizes: LINK_CARD_IMAGE_SIZES,
-        }
-      : { width: LINK_CARD_FAVICON_WIDTH }
-  );
-  linkCardImageCache.set(key, pending);
-  return pending;
-};
-
-/**
- * Re-points the `<img>`s satteri-link-card rendered at astro:assets-optimized
- * (webp, responsive) variants sized for the card's actual box, which also
- * moves the third-party thumbnails onto our own origin.
- *
- * Rewriting the serialized HTML rather than the hast tree is deliberate, for
- * the same reason `replaceRemoteImagePlaceholders` exists: satteri's
- * hastPlugins -- where satteri-link-card builds these nodes -- run during
- * content-layer sync, where `getImage()` is not usable.
- *
- * Anything that cannot be probed or optimized (an .ico favicon, an
- * unreachable host) keeps its original markup, courtesy of buildRemoteImage
- * returning null / the source url.
- */
-export const optimizeLinkCardImages = async (html: string): Promise<string> => {
-  const matches = [...html.matchAll(LINK_CARD_IMG)];
-  if (matches.length === 0) {
-    return html;
-  }
-  const replacements = await Promise.all(
-    matches.map(async (match) => {
-      const tag = match[0];
-      const src = SRC_ATTRIBUTE.exec(tag)?.[1];
-      if (!src) {
-        return [tag, tag] as const;
-      }
-      const kind = match[1] as "image" | "favicon";
-      const image = await linkCardImage(decodeHtml(src), kind);
-      if (!image) {
-        return [tag, tag] as const;
-      }
-      return [
-        tag,
-        withAttributes(tag, {
-          src: escapeHtml(image.src),
-          srcset: image.srcSet ? escapeHtml(image.srcSet) : undefined,
-          sizes: image.sizes,
-          // the favicon is the only one satteri-link-card leaves eager
-          loading: "lazy",
-        }),
-      ] as const;
-    })
-  );
-  let result = html;
-  for (const [tag, markup] of replacements) {
-    if (tag !== markup) {
-      result = result.replace(tag, () => markup);
-    }
   }
   return result;
 };

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -1,6 +1,12 @@
 import { getImage } from "astro:assets";
 import { getRemoteImageSize, getImagePlaceholder, escapeHtml } from "@miyamo2/astro-image-placeholder";
 import type { ImageMetadata } from "astro";
+import {
+  stagedImageMetadata,
+  stageRemoteImage,
+  stagingEnabled,
+  type StagedImage,
+} from "./staged-remote-image";
 
 export interface RemoteImageData {
   src: string;
@@ -43,37 +49,84 @@ const sizesFor = (targetWidth: number): string =>
 // here at the sizes we serve.
 const IMAGE_QUALITY = 80;
 
+// `width` + `height` is taken as given (the caller wants that exact box, and
+// getImage() crops to it); a lone `width` -- or neither, which means "up to
+// 800" -- is constrained to the source and keeps its aspect ratio.
+const resolveTargetSize = (
+  source: { width: number; height: number },
+  options: BuildRemoteImageOptions
+): { width: number; height: number } => {
+  if (options.width && options.height) {
+    return { width: options.width, height: options.height };
+  }
+  const width = Math.min(options.width ?? 800, source.width);
+  return { width, height: Math.round((width * source.height) / source.width) };
+};
+
+/**
+ * Builds an optimized (webp) image from an original this build has already
+ * downloaded and staged (see ./staged-remote-image), which astro:assets treats
+ * as a local image -- so its generation phase never touches the network.
+ */
+const buildStagedImage = async (
+  staged: StagedImage,
+  options: BuildRemoteImageOptions
+): Promise<RemoteImageData> => {
+  const { width: targetWidth, height: targetHeight } = resolveTargetSize(staged, options);
+  const meta = stagedImageMetadata(staged);
+  // same reason as buildCollectionImage: the image service's getHTMLAttributes
+  // hook cannot see a local image's fsPath, so the placeholder is fetched here
+  const placeholder = await getImagePlaceholder(meta).catch(() => undefined);
+  try {
+    const result = await getImage({
+      src: meta,
+      width: targetWidth,
+      height: targetHeight,
+      widths: srcsetWidths(targetWidth, staged.width),
+      format: "webp",
+      quality: IMAGE_QUALITY,
+      ...(options.width && options.height ? { fit: "cover" as const } : {}),
+    });
+    const srcSet = result.srcSet.attribute !== "" ? result.srcSet.attribute : undefined;
+    return {
+      src: result.src,
+      srcSet,
+      sizes: srcSet ? sizesFor(targetWidth) : undefined,
+      width: targetWidth,
+      height: targetHeight,
+      placeholder,
+    };
+  } catch (e) {
+    console.warn(`[images] failed to optimize ${staged.src}: ${String(e)}`);
+    // the staged original survives in the output: astro only deletes it after
+    // generating variants from it, which is exactly what did not happen here
+    return {
+      src: staged.src,
+      width: targetWidth,
+      height: targetHeight,
+      placeholder,
+    };
+  }
+};
+
 /**
  * Builds an optimized (webp) remote image via astro:assets, replacing
  * gatsby-plugin-image's gatsbyImageData. Dimension probing and the blur
  * placeholder are provided by @miyamo2/astro-image-placeholder's image
  * service (configured in astro.config.ts), so this only decides target
  * sizes and calls getImage().
+ *
+ * Only reachable outside a build -- see buildRemoteImage.
  */
-export const buildRemoteImage = async (
-  url: string | undefined | null,
-  options: BuildRemoteImageOptions = {}
+const buildUrlImage = async (
+  url: string,
+  options: BuildRemoteImageOptions
 ): Promise<RemoteImageData | null> => {
-  if (!url) {
-    return null;
-  }
   const size = await getRemoteImageSize(url);
   if (!size || size.width === 0 || size.height === 0) {
     return null;
   }
-
-  let targetWidth: number;
-  let targetHeight: number;
-  if (options.width && options.height) {
-    targetWidth = options.width;
-    targetHeight = options.height;
-  } else if (options.width) {
-    targetWidth = Math.min(options.width, size.width);
-    targetHeight = Math.round((targetWidth * size.height) / size.width);
-  } else {
-    targetWidth = Math.min(800, size.width);
-    targetHeight = Math.round((targetWidth * size.height) / size.width);
-  }
+  const { width: targetWidth, height: targetHeight } = resolveTargetSize(size, options);
 
   try {
     const result = await getImage({
@@ -105,6 +158,33 @@ export const buildRemoteImage = async (
 };
 
 /**
+ * Builds an optimized (webp) image from a remote url.
+ *
+ * A build must not hand that url to getImage() directly: astro would download
+ * it in its image-generation phase, where a host that has gone down, a 429, or
+ * a format sharp cannot decode aborts the whole build rather than this one
+ * image. So a build stages the bytes first (./staged-remote-image) and a
+ * failure is a `null` the caller renders around -- for article body images,
+ * `renderRemoteImageMarkup`'s plain `<img>` pointing back at the origin.
+ *
+ * `astro dev` has neither that phase nor a build output to stage into, and
+ * resolves a remote src per request, so there it keeps using the url.
+ */
+export const buildRemoteImage = async (
+  url: string | undefined | null,
+  options: BuildRemoteImageOptions = {}
+): Promise<RemoteImageData | null> => {
+  if (!url) {
+    return null;
+  }
+  if (!stagingEnabled()) {
+    return buildUrlImage(url, options);
+  }
+  const staged = await stageRemoteImage(url);
+  return staged ? await buildStagedImage(staged, options) : null;
+};
+
+/**
  * Builds an optimized (webp) image from a local content-collection image
  * (thumbnails downloaded by @miyamo2/astro-loader-blogapi-miyamo-today),
  * producing the same RemoteImageData shape as buildRemoteImage.
@@ -116,19 +196,7 @@ export const buildCollectionImage = async (
   if (!meta || meta.width === 0 || meta.height === 0) {
     return null;
   }
-
-  let targetWidth: number;
-  let targetHeight: number;
-  if (options.width && options.height) {
-    targetWidth = options.width;
-    targetHeight = options.height;
-  } else if (options.width) {
-    targetWidth = Math.min(options.width, meta.width);
-    targetHeight = Math.round((targetWidth * meta.height) / meta.width);
-  } else {
-    targetWidth = Math.min(800, meta.width);
-    targetHeight = Math.round((targetWidth * meta.height) / meta.width);
-  }
+  const { width: targetWidth, height: targetHeight } = resolveTargetSize(meta, options);
 
   // the image service's getHTMLAttributes hook cannot see local images'
   // fsPath (getImage() clones the metadata before invoking any hook, and

--- a/src/lib/link-card-images.ts
+++ b/src/lib/link-card-images.ts
@@ -1,9 +1,11 @@
-import { createHash } from "node:crypto";
-import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
 import { getImage } from "astro:assets";
 import { escapeHtml } from "@miyamo2/astro-image-placeholder";
-import pLimit from "p-limit";
+import {
+  stagedImageMetadata,
+  stageRemoteImage,
+  stagingEnabled,
+  type StagedImage,
+} from "./staged-remote-image";
 
 // satteri-link-card emits the OGP image / favicon URLs it scraped verbatim (its
 // own `imageCache` only self-hosts the original bytes, it never resizes), so a
@@ -25,42 +27,7 @@ const FAVICON_SIZES = `${FAVICON_WIDTH}px`;
 
 const IMAGE_QUALITY = 80;
 
-const FETCH_TIMEOUT_MS = 10_000;
-const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
-// re-fetching every build only costs us rate limits
-// (opengraph.githubassets.com starts answering 429 well before a full build's
-// worth of requests is through). The TTL is also what eventually stops us
-// serving an image whose source has been taken down: once it expires, a
-// re-fetch that fails drops the card back to the origin's own URL.
-const ORIGINAL_CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
-
-// astro's image service refuses SVG unless `image.dangerouslyProcessSVG` is on,
-// and sharp cannot decode .ico at all. Either one reaching getImage() aborts
-// the *whole build* from the "generating optimized images" phase (astro
-// rethrows every asset-generation error), so the format is checked against the
-// bytes we downloaded -- not against the URL, which lies often enough.
-const DECODABLE_FORMATS = new Set(["jpeg", "png", "webp", "avif", "gif", "tiff"]);
-
-const EXTENSIONS: Record<string, string> = { jpeg: "jpg" };
-
-/**
- * Assets folder of the build output. The originals are staged there so the
- * variants astro derives from them land next to every other hashed asset --
- * the deploy step uploads `dist/_astro` first and as `immutable` (see
- * .github/workflows/publish.yaml), which is exactly what these are.
- */
-const ASSETS_DIR = (): string => process.env.LINK_CARD_IMAGE_ASSETS_DIR || "_astro";
-
 type Kind = "image" | "favicon";
-
-interface StagedImage {
-  /** path relative to the build output root, which is how astro:assets addresses it */
-  src: string;
-  fsPath: string;
-  width: number;
-  height: number;
-  format: string;
-}
 
 interface OptimizedImage {
   src: string;
@@ -68,117 +35,7 @@ interface OptimizedImage {
   sizes: string;
 }
 
-/**
- * Build output / cache directories, published by the `link-card-images`
- * integration in astro.config.ts. Page rendering and the astro config live in
- * separate module graphs, so process.env is the only channel between them;
- * their absence means "not a production build", and optimization is skipped
- * (`astro dev` has no build output to stage originals into).
- */
-const outDir = (): string | undefined => process.env.LINK_CARD_IMAGE_OUT_DIR || undefined;
-const cacheDir = (): string | undefined => process.env.LINK_CARD_IMAGE_CACHE_DIR || undefined;
-
-const keyFor = (url: string): string => createHash("sha1").update(url).digest("hex").slice(0, 16);
-
-const fetchImageBytes = async (url: string): Promise<Buffer | null> => {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-  try {
-    const response = await fetch(url, {
-      headers: { accept: "image/*" },
-      signal: controller.signal,
-    });
-    if (!response.ok) {
-      return null;
-    }
-    const bytes = Buffer.from(await response.arrayBuffer());
-    return bytes.length > 0 && bytes.length <= MAX_IMAGE_BYTES ? bytes : null;
-  } catch {
-    return null;
-  } finally {
-    clearTimeout(timeout);
-  }
-};
-
-const downloadOriginal = async (url: string): Promise<Buffer | null> => {
-  const cache = cacheDir();
-  const cacheFile = cache ? join(cache, "link-card-images", keyFor(url)) : undefined;
-  if (cacheFile) {
-    try {
-      const info = await stat(cacheFile);
-      if (Date.now() - info.mtimeMs < ORIGINAL_CACHE_TTL_MS) {
-        return await readFile(cacheFile);
-      }
-    } catch {
-      // not cached yet (or unreadable) -- fall through to the network
-    }
-  }
-  const bytes = await fetchImageBytes(url);
-  if (!bytes) {
-    return null;
-  }
-  if (cacheFile) {
-    try {
-      await mkdir(dirname(cacheFile), { recursive: true });
-      await writeFile(cacheFile, bytes);
-    } catch {
-      // caching is best-effort
-    }
-  }
-  return bytes;
-};
-
-/**
- * Downloads one link card image and writes it into the build output, where
- * astro:assets reads a *local* image's bytes from.
- *
- * Handing astro the URL directly would be less code, but it defers the download
- * to astro's own generation phase -- and any failure there fails the *entire*
- * build, since astro rethrows every asset-generation error. These URLs are
- * scraped from live third-party pages: hosts go down, rate limit, and serve
- * formats sharp cannot read. Downloading here turns every one of those into a
- * `null` that leaves the original markup alone.
- *
- * The staged original is deleted again by astro once it has produced the
- * variants, since nothing else references it.
- */
-const stageOriginal = async (url: string): Promise<StagedImage | null> => {
-  const out = outDir();
-  if (!out) {
-    return null;
-  }
-  const bytes = await downloadOriginal(url);
-  if (!bytes) {
-    return null;
-  }
-  let format: string | undefined;
-  let width: number | undefined;
-  let height: number | undefined;
-  try {
-    const sharp = (await import("sharp")).default;
-    ({ format, width, height } = await sharp(bytes).metadata());
-  } catch {
-    return null;
-  }
-  if (!format || !DECODABLE_FORMATS.has(format) || !width || !height) {
-    return null;
-  }
-  const src = `/${ASSETS_DIR()}/${keyFor(url)}.${EXTENSIONS[format] ?? format}`;
-  const fsPath = join(out, src);
-  try {
-    await mkdir(dirname(fsPath), { recursive: true });
-    await writeFile(fsPath, bytes);
-  } catch {
-    return null;
-  }
-  return { src, fsPath, width, height, format };
-};
-
-const optimize = async (url: string, kind: Kind): Promise<OptimizedImage | null> => {
-  const staged = await stageOriginal(url);
-  if (!staged) {
-    return null;
-  }
+const optimize = async (staged: StagedImage, kind: Kind): Promise<OptimizedImage | null> => {
   const isThumbnail = kind === "image";
   const targetWidth = isThumbnail ? THUMBNAIL_WIDTH : FAVICON_WIDTH;
   const targetHeight = isThumbnail
@@ -191,13 +48,7 @@ const optimize = async (url: string, kind: Kind): Promise<OptimizedImage | null>
   );
   try {
     const result = await getImage({
-      src: {
-        src: staged.src,
-        fsPath: staged.fsPath,
-        width: staged.width,
-        height: staged.height,
-        format: staged.format,
-      } as Parameters<typeof getImage>[0]["src"],
+      src: stagedImageMetadata(staged),
       width: targetWidth,
       height: targetHeight,
       widths: widths.length > 0 ? widths : [Math.min(targetWidth, staged.width)],
@@ -212,26 +63,16 @@ const optimize = async (url: string, kind: Kind): Promise<OptimizedImage | null>
       sizes: isThumbnail ? THUMBNAIL_SIZES : FAVICON_SIZES,
     };
   } catch (e) {
-    console.warn(`[link-card-images] failed to optimize ${url}: ${String(e)}`);
+    console.warn(`[link-card-images] failed to optimize ${staged.src}: ${String(e)}`);
     return null;
   }
 };
 
-// one build meets the same og:image and (especially) the same favicon over and
-// over -- articles link to the same hosts repeatedly. The concurrency cap keeps
-// us from bursting a single host hard enough to be rate limited.
-const inflight = new Map<string, Promise<OptimizedImage | null>>();
-const limit = pLimit(4);
-
-const optimizeOnce = (url: string, kind: Kind): Promise<OptimizedImage | null> => {
-  const key = `${kind}:${url}`;
-  const pending = inflight.get(key);
-  if (pending) {
-    return pending;
-  }
-  const request = limit(() => optimize(url, kind));
-  inflight.set(key, request);
-  return request;
+// stageRemoteImage already dedupes and rate limits the download itself; this
+// only avoids repeating the (cheap) getImage() bookkeeping per occurrence
+const optimizeOnce = async (url: string, kind: Kind): Promise<OptimizedImage | null> => {
+  const staged = await stageRemoteImage(url);
+  return staged ? await optimize(staged, kind) : null;
 };
 
 const LINK_CARD_IMG = /<img\b[^>]*\bclass="satteri-link-card__(image|favicon)"[^>]*>/g;
@@ -275,7 +116,7 @@ const withAttributes = (tag: string, attributes: Record<string, string | undefin
  */
 export const optimizeLinkCardImages = async (html: string): Promise<string> => {
   const matches = [...html.matchAll(LINK_CARD_IMG)];
-  if (matches.length === 0 || !outDir()) {
+  if (matches.length === 0 || !stagingEnabled()) {
     return html;
   }
   const replacements = await Promise.all(

--- a/src/lib/link-card-images.ts
+++ b/src/lib/link-card-images.ts
@@ -1,0 +1,313 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { getImage } from "astro:assets";
+import { escapeHtml } from "@miyamo2/astro-image-placeholder";
+import pLimit from "p-limit";
+
+// satteri-link-card emits the OGP image / favicon URLs it scraped verbatim (its
+// own `imageCache` only self-hosts the original bytes, it never resizes), so a
+// 1200x600 og:image lands in a box that is never wider than ~273 CSS px and a
+// 512x512 favicon in a 14x14 one -- PageSpeed Insights' "Improve image
+// delivery". These constants describe those boxes; see
+// `.satteri-link-card__media` / `__favicon` in styles/vendor.css.
+const THUMBNAIL_WIDTH = 280;
+const THUMBNAIL_HEIGHT = 140;
+// 448w is the candidate lighthouse's mobile run asks for (412px viewport, 40vw
+// slot, DPR 1.75); 560w covers the widest desktop box (273px) at DPR 2
+const THUMBNAIL_WIDTHS = [160, 280, 448, 560];
+// the media box is 40% of the card below 768px and 30% above it; the card is
+// the content column, which stops growing at 1400px * 65% (article-detail.css)
+const THUMBNAIL_SIZES = `(min-width: 1200px) ${THUMBNAIL_WIDTH}px, (min-width: 768px) 30vw, 40vw`;
+const FAVICON_WIDTH = 14;
+const FAVICON_WIDTHS = [14, 28];
+const FAVICON_SIZES = `${FAVICON_WIDTH}px`;
+
+const IMAGE_QUALITY = 80;
+
+const FETCH_TIMEOUT_MS = 10_000;
+const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
+// re-fetching every build only costs us rate limits
+// (opengraph.githubassets.com starts answering 429 well before a full build's
+// worth of requests is through). The TTL is also what eventually stops us
+// serving an image whose source has been taken down: once it expires, a
+// re-fetch that fails drops the card back to the origin's own URL.
+const ORIGINAL_CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+// astro's image service refuses SVG unless `image.dangerouslyProcessSVG` is on,
+// and sharp cannot decode .ico at all. Either one reaching getImage() aborts
+// the *whole build* from the "generating optimized images" phase (astro
+// rethrows every asset-generation error), so the format is checked against the
+// bytes we downloaded -- not against the URL, which lies often enough.
+const DECODABLE_FORMATS = new Set(["jpeg", "png", "webp", "avif", "gif", "tiff"]);
+
+const EXTENSIONS: Record<string, string> = { jpeg: "jpg" };
+
+/**
+ * Assets folder of the build output. The originals are staged there so the
+ * variants astro derives from them land next to every other hashed asset --
+ * the deploy step uploads `dist/_astro` first and as `immutable` (see
+ * .github/workflows/publish.yaml), which is exactly what these are.
+ */
+const ASSETS_DIR = (): string => process.env.LINK_CARD_IMAGE_ASSETS_DIR || "_astro";
+
+type Kind = "image" | "favicon";
+
+interface StagedImage {
+  /** path relative to the build output root, which is how astro:assets addresses it */
+  src: string;
+  fsPath: string;
+  width: number;
+  height: number;
+  format: string;
+}
+
+interface OptimizedImage {
+  src: string;
+  srcSet?: string;
+  sizes: string;
+}
+
+/**
+ * Build output / cache directories, published by the `link-card-images`
+ * integration in astro.config.ts. Page rendering and the astro config live in
+ * separate module graphs, so process.env is the only channel between them;
+ * their absence means "not a production build", and optimization is skipped
+ * (`astro dev` has no build output to stage originals into).
+ */
+const outDir = (): string | undefined => process.env.LINK_CARD_IMAGE_OUT_DIR || undefined;
+const cacheDir = (): string | undefined => process.env.LINK_CARD_IMAGE_CACHE_DIR || undefined;
+
+const keyFor = (url: string): string => createHash("sha1").update(url).digest("hex").slice(0, 16);
+
+const fetchImageBytes = async (url: string): Promise<Buffer | null> => {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      headers: { accept: "image/*" },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      return null;
+    }
+    const bytes = Buffer.from(await response.arrayBuffer());
+    return bytes.length > 0 && bytes.length <= MAX_IMAGE_BYTES ? bytes : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+
+const downloadOriginal = async (url: string): Promise<Buffer | null> => {
+  const cache = cacheDir();
+  const cacheFile = cache ? join(cache, "link-card-images", keyFor(url)) : undefined;
+  if (cacheFile) {
+    try {
+      const info = await stat(cacheFile);
+      if (Date.now() - info.mtimeMs < ORIGINAL_CACHE_TTL_MS) {
+        return await readFile(cacheFile);
+      }
+    } catch {
+      // not cached yet (or unreadable) -- fall through to the network
+    }
+  }
+  const bytes = await fetchImageBytes(url);
+  if (!bytes) {
+    return null;
+  }
+  if (cacheFile) {
+    try {
+      await mkdir(dirname(cacheFile), { recursive: true });
+      await writeFile(cacheFile, bytes);
+    } catch {
+      // caching is best-effort
+    }
+  }
+  return bytes;
+};
+
+/**
+ * Downloads one link card image and writes it into the build output, where
+ * astro:assets reads a *local* image's bytes from.
+ *
+ * Handing astro the URL directly would be less code, but it defers the download
+ * to astro's own generation phase -- and any failure there fails the *entire*
+ * build, since astro rethrows every asset-generation error. These URLs are
+ * scraped from live third-party pages: hosts go down, rate limit, and serve
+ * formats sharp cannot read. Downloading here turns every one of those into a
+ * `null` that leaves the original markup alone.
+ *
+ * The staged original is deleted again by astro once it has produced the
+ * variants, since nothing else references it.
+ */
+const stageOriginal = async (url: string): Promise<StagedImage | null> => {
+  const out = outDir();
+  if (!out) {
+    return null;
+  }
+  const bytes = await downloadOriginal(url);
+  if (!bytes) {
+    return null;
+  }
+  let format: string | undefined;
+  let width: number | undefined;
+  let height: number | undefined;
+  try {
+    const sharp = (await import("sharp")).default;
+    ({ format, width, height } = await sharp(bytes).metadata());
+  } catch {
+    return null;
+  }
+  if (!format || !DECODABLE_FORMATS.has(format) || !width || !height) {
+    return null;
+  }
+  const src = `/${ASSETS_DIR()}/${keyFor(url)}.${EXTENSIONS[format] ?? format}`;
+  const fsPath = join(out, src);
+  try {
+    await mkdir(dirname(fsPath), { recursive: true });
+    await writeFile(fsPath, bytes);
+  } catch {
+    return null;
+  }
+  return { src, fsPath, width, height, format };
+};
+
+const optimize = async (url: string, kind: Kind): Promise<OptimizedImage | null> => {
+  const staged = await stageOriginal(url);
+  if (!staged) {
+    return null;
+  }
+  const isThumbnail = kind === "image";
+  const targetWidth = isThumbnail ? THUMBNAIL_WIDTH : FAVICON_WIDTH;
+  const targetHeight = isThumbnail
+    ? THUMBNAIL_HEIGHT
+    : // favicons are not always square; keep their aspect and let the CSS box crop
+      Math.max(1, Math.round((FAVICON_WIDTH * staged.height) / staged.width));
+  // never upscale past the source: those variants are bytes with no detail
+  const widths = (isThumbnail ? THUMBNAIL_WIDTHS : FAVICON_WIDTHS).filter(
+    (width) => width <= staged.width
+  );
+  try {
+    const result = await getImage({
+      src: {
+        src: staged.src,
+        fsPath: staged.fsPath,
+        width: staged.width,
+        height: staged.height,
+        format: staged.format,
+      } as Parameters<typeof getImage>[0]["src"],
+      width: targetWidth,
+      height: targetHeight,
+      widths: widths.length > 0 ? widths : [Math.min(targetWidth, staged.width)],
+      format: "webp",
+      quality: IMAGE_QUALITY,
+      // the thumbnail box is not exactly 2:1, so the source has to be cropped
+      ...(isThumbnail ? { fit: "cover" as const } : {}),
+    });
+    return {
+      src: result.src,
+      srcSet: result.srcSet.attribute !== "" ? result.srcSet.attribute : undefined,
+      sizes: isThumbnail ? THUMBNAIL_SIZES : FAVICON_SIZES,
+    };
+  } catch (e) {
+    console.warn(`[link-card-images] failed to optimize ${url}: ${String(e)}`);
+    return null;
+  }
+};
+
+// one build meets the same og:image and (especially) the same favicon over and
+// over -- articles link to the same hosts repeatedly. The concurrency cap keeps
+// us from bursting a single host hard enough to be rate limited.
+const inflight = new Map<string, Promise<OptimizedImage | null>>();
+const limit = pLimit(4);
+
+const optimizeOnce = (url: string, kind: Kind): Promise<OptimizedImage | null> => {
+  const key = `${kind}:${url}`;
+  const pending = inflight.get(key);
+  if (pending) {
+    return pending;
+  }
+  const request = limit(() => optimize(url, kind));
+  inflight.set(key, request);
+  return request;
+};
+
+const LINK_CARD_IMG = /<img\b[^>]*\bclass="satteri-link-card__(image|favicon)"[^>]*>/g;
+const SRC_ATTRIBUTE = /\ssrc="([^"]*)"/;
+
+const decodeHtml = (value: string): string =>
+  value
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    // last: an escaped entity must not be produced by an earlier replacement
+    .replace(/&amp;/g, "&");
+
+/** sets (or adds, keeping the tag's self-closing form) attributes on one tag */
+const withAttributes = (tag: string, attributes: Record<string, string | undefined>): string => {
+  let result = tag;
+  for (const [name, value] of Object.entries(attributes)) {
+    if (value === undefined) {
+      continue;
+    }
+    const attribute = ` ${name}="${value}"`;
+    const existing = new RegExp(`\\s${name}="[^"]*"`);
+    result = existing.test(result)
+      ? result.replace(existing, () => attribute)
+      : result.replace(/\s*\/?>$/, (close) => `${attribute}${close}`);
+  }
+  return result;
+};
+
+/**
+ * Re-points the `<img>`s satteri-link-card rendered at responsive webp variants
+ * sized for the card's actual box, which also moves the third-party thumbnails
+ * onto our own origin. Anything that could not be optimized keeps its original
+ * URL and only gains the `lazy` satteri-link-card omits on favicons.
+ *
+ * Rewriting the serialized HTML rather than the hast tree is deliberate, for
+ * the same reason `replaceRemoteImagePlaceholders` (./images) exists: satteri's
+ * hastPlugins -- where satteri-link-card builds these nodes -- run during
+ * content-layer sync, where `getImage()` is not usable.
+ */
+export const optimizeLinkCardImages = async (html: string): Promise<string> => {
+  const matches = [...html.matchAll(LINK_CARD_IMG)];
+  if (matches.length === 0 || !outDir()) {
+    return html;
+  }
+  const replacements = await Promise.all(
+    matches.map(async (match) => {
+      const tag = match[0];
+      const src = SRC_ATTRIBUTE.exec(tag)?.[1];
+      if (!src) {
+        return [tag, tag] as const;
+      }
+      const image = await optimizeOnce(decodeHtml(src), match[1] as Kind);
+      return [
+        tag,
+        withAttributes(tag, {
+          ...(image
+            ? {
+                src: escapeHtml(image.src),
+                srcset: image.srcSet ? escapeHtml(image.srcSet) : undefined,
+                sizes: image.sizes,
+              }
+            : {}),
+          // the favicon is the only one satteri-link-card leaves eager, and
+          // deferring it is worth doing even when the bytes stay third-party
+          loading: "lazy",
+        }),
+      ] as const;
+    })
+  );
+  let result = html;
+  for (const [tag, markup] of replacements) {
+    if (tag !== markup) {
+      result = result.replace(tag, () => markup);
+    }
+  }
+  return result;
+};

--- a/src/lib/staged-remote-image.ts
+++ b/src/lib/staged-remote-image.ts
@@ -3,6 +3,11 @@ import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import pLimit from "p-limit";
 import type { ImageMetadata } from "astro";
+import {
+  remoteImageAssetsDir,
+  remoteImageCacheDir,
+  remoteImageOutDir,
+} from "../../integrations/remote-image-staging/env";
 
 const FETCH_TIMEOUT_MS = 10_000;
 const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
@@ -32,27 +37,12 @@ export interface StagedImage {
 }
 
 /**
- * Build output / cache / assets directories, published by the
- * `remoteImageStaging` integration in astro.config.ts. Page rendering and the
- * astro config live in separate module graphs, so process.env is the only
- * channel between them; their absence means "not a production build".
- */
-const outDir = (): string | undefined => process.env.REMOTE_IMAGE_OUT_DIR || undefined;
-const cacheDir = (): string | undefined => process.env.REMOTE_IMAGE_CACHE_DIR || undefined;
-/**
- * Originals are staged in the assets folder so the variants astro derives from
- * them land next to every other hashed asset -- the deploy step uploads
- * `dist/_astro` first and as `immutable` (see .github/workflows/publish.yaml),
- * which is exactly what they are.
- */
-const assetsDir = (): string => process.env.REMOTE_IMAGE_ASSETS_DIR || "_astro";
-
-/**
  * Whether remote images have to be staged before astro:assets may see them.
- * True during `astro build` only: `astro dev` resolves a remote src per
+ * True during `astro build` only -- that is when the `remote-image-staging`
+ * integration publishes the directories. `astro dev` resolves a remote src per
  * request, where a failure costs one broken image rather than the build.
  */
-export const stagingEnabled = (): boolean => outDir() !== undefined;
+export const stagingEnabled = (): boolean => remoteImageOutDir() !== undefined;
 
 const keyFor = (url: string): string => createHash("sha1").update(url).digest("hex").slice(0, 16);
 
@@ -77,7 +67,7 @@ const fetchImageBytes = async (url: string): Promise<Buffer | null> => {
 };
 
 const downloadOriginal = async (url: string): Promise<Buffer | null> => {
-  const cache = cacheDir();
+  const cache = remoteImageCacheDir();
   const cacheFile = cache ? join(cache, "remote-images", keyFor(url)) : undefined;
   if (cacheFile) {
     try {
@@ -121,7 +111,7 @@ const downloadOriginal = async (url: string): Promise<Buffer | null> => {
  * variants, since nothing else references it.
  */
 const stage = async (url: string): Promise<StagedImage | null> => {
-  const out = outDir();
+  const out = remoteImageOutDir();
   if (!out) {
     return null;
   }
@@ -141,7 +131,7 @@ const stage = async (url: string): Promise<StagedImage | null> => {
   if (!format || !DECODABLE_FORMATS.has(format) || !width || !height) {
     return null;
   }
-  const src = `/${assetsDir()}/${keyFor(url)}.${EXTENSIONS[format] ?? format}`;
+  const src = `/${remoteImageAssetsDir()}/${keyFor(url)}.${EXTENSIONS[format] ?? format}`;
   const fsPath = join(out, src);
   try {
     await mkdir(dirname(fsPath), { recursive: true });

--- a/src/lib/staged-remote-image.ts
+++ b/src/lib/staged-remote-image.ts
@@ -1,0 +1,180 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import pLimit from "p-limit";
+import type { ImageMetadata } from "astro";
+
+const FETCH_TIMEOUT_MS = 10_000;
+const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
+// re-fetching every build only costs us rate limits
+// (opengraph.githubassets.com starts answering 429 well before a full build's
+// worth of requests is through). The TTL is also what eventually stops us
+// serving an image whose source has been taken down: once it expires, a
+// re-fetch that fails drops the markup back to the origin's own URL.
+const ORIGINAL_CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+// astro's image service refuses SVG unless `image.dangerouslyProcessSVG` is on,
+// and sharp cannot decode .ico at all. The format is checked against the bytes
+// we downloaded rather than the URL, which lies often enough -- and which is
+// exactly how a `.svg` favicon slipped through the `getRemoteImageSize` probe
+// (image-size reads SVG dimensions happily) and aborted a build.
+const DECODABLE_FORMATS = new Set(["jpeg", "png", "webp", "avif", "gif", "tiff"]);
+
+const EXTENSIONS: Record<string, string> = { jpeg: "jpg" };
+
+export interface StagedImage {
+  /** path relative to the build output root, which is how astro:assets addresses it */
+  src: string;
+  fsPath: string;
+  width: number;
+  height: number;
+  format: string;
+}
+
+/**
+ * Build output / cache / assets directories, published by the
+ * `remoteImageStaging` integration in astro.config.ts. Page rendering and the
+ * astro config live in separate module graphs, so process.env is the only
+ * channel between them; their absence means "not a production build".
+ */
+const outDir = (): string | undefined => process.env.REMOTE_IMAGE_OUT_DIR || undefined;
+const cacheDir = (): string | undefined => process.env.REMOTE_IMAGE_CACHE_DIR || undefined;
+/**
+ * Originals are staged in the assets folder so the variants astro derives from
+ * them land next to every other hashed asset -- the deploy step uploads
+ * `dist/_astro` first and as `immutable` (see .github/workflows/publish.yaml),
+ * which is exactly what they are.
+ */
+const assetsDir = (): string => process.env.REMOTE_IMAGE_ASSETS_DIR || "_astro";
+
+/**
+ * Whether remote images have to be staged before astro:assets may see them.
+ * True during `astro build` only: `astro dev` resolves a remote src per
+ * request, where a failure costs one broken image rather than the build.
+ */
+export const stagingEnabled = (): boolean => outDir() !== undefined;
+
+const keyFor = (url: string): string => createHash("sha1").update(url).digest("hex").slice(0, 16);
+
+const fetchImageBytes = async (url: string): Promise<Buffer | null> => {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      headers: { accept: "image/*" },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      return null;
+    }
+    const bytes = Buffer.from(await response.arrayBuffer());
+    return bytes.length > 0 && bytes.length <= MAX_IMAGE_BYTES ? bytes : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+
+const downloadOriginal = async (url: string): Promise<Buffer | null> => {
+  const cache = cacheDir();
+  const cacheFile = cache ? join(cache, "remote-images", keyFor(url)) : undefined;
+  if (cacheFile) {
+    try {
+      const info = await stat(cacheFile);
+      if (Date.now() - info.mtimeMs < ORIGINAL_CACHE_TTL_MS) {
+        return await readFile(cacheFile);
+      }
+    } catch {
+      // not cached yet (or unreadable) -- fall through to the network
+    }
+  }
+  const bytes = await fetchImageBytes(url);
+  if (!bytes) {
+    return null;
+  }
+  if (cacheFile) {
+    try {
+      await mkdir(dirname(cacheFile), { recursive: true });
+      await writeFile(cacheFile, bytes);
+    } catch {
+      // caching is best-effort
+    }
+  }
+  return bytes;
+};
+
+/**
+ * Downloads one remote image and writes it into the build output, where
+ * astro:assets reads a *local* image's bytes from.
+ *
+ * Handing astro the URL directly would be less code, but it defers the download
+ * to astro's own image-generation phase -- and any failure there fails the
+ * *entire* build, since astro rethrows every asset-generation error
+ * (`astro/dist/core/build/generate.js`). A `getRemoteImageSize` probe before
+ * the call is not a guard: it runs while routes are generated, up to a minute
+ * before the phase that downloads, and formats it can read are not the same set
+ * sharp can decode. Downloading here turns all of that into a `null` the caller
+ * renders around, and halves the requests per image on the way.
+ *
+ * The staged original is deleted again by astro once it has produced the
+ * variants, since nothing else references it.
+ */
+const stage = async (url: string): Promise<StagedImage | null> => {
+  const out = outDir();
+  if (!out) {
+    return null;
+  }
+  const bytes = await downloadOriginal(url);
+  if (!bytes) {
+    return null;
+  }
+  let format: string | undefined;
+  let width: number | undefined;
+  let height: number | undefined;
+  try {
+    const sharp = (await import("sharp")).default;
+    ({ format, width, height } = await sharp(bytes).metadata());
+  } catch {
+    return null;
+  }
+  if (!format || !DECODABLE_FORMATS.has(format) || !width || !height) {
+    return null;
+  }
+  const src = `/${assetsDir()}/${keyFor(url)}.${EXTENSIONS[format] ?? format}`;
+  const fsPath = join(out, src);
+  try {
+    await mkdir(dirname(fsPath), { recursive: true });
+    await writeFile(fsPath, bytes);
+  } catch {
+    return null;
+  }
+  return { src, fsPath, width, height, format };
+};
+
+// one build meets the same url over and over -- articles link to the same hosts
+// repeatedly, and an og:image is both a link card thumbnail and, elsewhere, a
+// body image. The concurrency cap keeps us from bursting a single host hard
+// enough to be rate limited.
+const inflight = new Map<string, Promise<StagedImage | null>>();
+const limit = pLimit(4);
+
+export const stageRemoteImage = (url: string): Promise<StagedImage | null> => {
+  const pending = inflight.get(url);
+  if (pending) {
+    return pending;
+  }
+  const request = limit(() => stage(url));
+  inflight.set(url, request);
+  return request;
+};
+
+/** the shape astro:assets needs to treat a staged original as a local image */
+export const stagedImageMetadata = (staged: StagedImage): ImageMetadata =>
+  ({
+    src: staged.src,
+    fsPath: staged.fsPath,
+    width: staged.width,
+    height: staged.height,
+    format: staged.format,
+  }) as ImageMetadata;


### PR DESCRIPTION
#70 が `main` のビルドを壊したのでその修正。加えて、同じ構造のリスクを持っていた記事本文のリモート画像も同じ方式に寄せた。

## 原因

`getImage()` は変換を登録するだけで、実際のダウンロードは後段の `generating optimized images` フェーズで行われる。そこでのエラーは Astro が全て再スローするため、**サードパーティのホストが 1 つ落ちているだけでビルド全体が落ちる**。

前段の `getRemoteImageSize` probe はガードにならない。probe と実ダウンロードは最大 90 秒離れており、image-size は SVG の寸法も読めてしまう。

## 修正

自前でバイト列を取得してビルド出力にステージし、**ローカル画像として** `getImage()` に渡す。生成フェーズはネットワークに触れなくなる。

- 形式判定は URL ではなく実バイトの sharp メタデータで行う → SVG / `.ico` を確実に除外
- 失敗（到達不能・404・429・デコード不可）は `null` になり、呼び出し側が元 URL にフォールバック。**ビルドは落ちない**
- probe が不要になり取得は 1 画像 1 回に。URL 単位で dedupe・同時 4 本に制限、原本は `.cache` に 30 日保持
- `astro dev` は従来通りリクエスト毎に解決（生成フェーズが無いため）

記事本文の `buildRemoteImage` も同じ機構を通す。今の `main` は記事に `[](https://.../x.svg)` を 1 行書くだけで落ちる状態のため。

#70 が `buildRemoteImage` / `buildCollectionImage` に足した `widths` / `sizes` は revert 済み。

## 構成

| パス | 役割 |
|---|---|
| `integrations/remote-image-staging/` | integration 本体と、`src/lib` との env 契約 |
| `src/lib/staged-remote-image.ts` | 取得・キャッシュ・形式判定・ステージ |
| `src/lib/link-card-images.ts` | リンクカードのサイズ決定と HTML 書き換え |
| `src/lib/images.ts` | `buildRemoteImage` をステージ経由に |