### PR TITLE
perf: load gtag.js from an idle callback to drop its forced reflow

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -14,6 +14,7 @@ import {
   codeCopyButtonPlugin,
   remoteImagesMdastPlugin,
 } from "./src/lib/satteri-plugins";
+import inlineScripts from "./src/integrations/inline-scripts";
 
 // `.env` files are not loaded into process.env while the config itself is being
 // evaluated, so load them explicitly here (empty prefix -> load every var).
@@ -91,6 +92,7 @@ export default defineConfig({
     ),
   },
   integrations: [
+    inlineScripts(),
     blogApiMiyamoToday({
       url: env.BLOG_API_MIYAMO_TODAY_URL ?? "",
       token: env.BLOG_API_MIYAMO_TODAY_TOKEN ?? "",

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -38,9 +38,46 @@ const seo = {
 };
 
 const gtagId = "G-F1N7VJ0ZX9";
+// gtag.js measures the page as soon as it evaluates (it reads document/viewport
+// geometry to set up scroll tracking). Pulling it in with `async` from <head>
+// meant that read landed while the document was still being parsed and styled,
+// so it forced a synchronous layout of the whole page -- ~70ms of the "forced
+// reflow" the DevTools performance panel reports.
+//
+// Only the dataLayer queue below has to run early: gtag() just pushes onto an
+// array and gtag.js replays whatever is queued the moment it arrives, so the
+// hit timestamps (`gtag('js', new Date())`) stay accurate no matter when the
+// library shows up. That lets the library itself wait until the page has
+// painted and the main thread goes idle, when layout is already clean and the
+// same measurement costs nothing.
+//
 // astro:after-swap fires on ClientRouter navigations only (not the initial
-// load, which gtag('config') already reports), after the new <title> is set
-const gtagInit = `window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', '${gtagId}');document.addEventListener('astro:after-swap', function () {gtag('event', 'page_view', {page_location: location.href, page_title: document.title});});`;
+// load, which gtag('config') already reports), after the new <title> is set.
+// The ClientRouter skips inline scripts it has already executed (matched on
+// their text), so this whole block runs once per full page load -- the
+// listener is never registered twice and the library is never re-requested.
+const gtagInit = `window.dataLayer = window.dataLayer || [];
+function gtag() { dataLayer.push(arguments); }
+gtag('js', new Date());
+gtag('config', '${gtagId}');
+document.addEventListener('astro:after-swap', function () {
+  gtag('event', 'page_view', { page_location: location.href, page_title: document.title });
+});
+(function () {
+  function load() {
+    var script = document.createElement('script');
+    script.async = true;
+    script.src = 'https://www.googletagmanager.com/gtag/js?id=${gtagId}';
+    document.head.appendChild(script);
+  }
+  function schedule() {
+    // the timeout bounds the wait on a main thread that never actually idles
+    if (window.requestIdleCallback) requestIdleCallback(load, { timeout: 2000 });
+    else setTimeout(load, 500);
+  }
+  if (document.readyState === 'complete') schedule();
+  else window.addEventListener('load', schedule, { once: true });
+})();`;
 
 // gatsby-plugin-manifest icon set
 const manifestIconSizes = [48, 72, 96, 144, 192, 256, 384, 512];
@@ -50,12 +87,14 @@ const manifestIconSizes = [48, 72, 96, 144, 192, 256, 384, 512];
 // every cross-origin subresource here (scripts, stylesheets, images) is fetched
 // in no-cors mode, so a crossorigin preconnect would sit unused. The only
 // CORS-fetched resources are the fonts, and those are same-origin.
+// www.googletagmanager.com is deliberately absent: gtag.js is now requested
+// from an idle callback after load (see above), long after the preconnected
+// socket would have been reclaimed, so warming it here would only take a
+// connection slot away from the resources that do load with the page.
 const preconnectDomains = [
   // Buy Me a Coffee widget loader, then the widget's own assets
   "https://cdnjs.buymeacoffee.com",
   "https://cdn.buymeacoffee.com",
-  // gtag.js (production only, see below)
-  "https://www.googletagmanager.com",
 ];
 ---
 
@@ -128,11 +167,4 @@ const preconnectDomains = [
 }
 
 {/* gatsby-plugin-google-gtag (head: true, production only) */}
-{
-  import.meta.env.PROD && (
-    <>
-      <script is:inline async src={`https://www.googletagmanager.com/gtag/js?id=${gtagId}`} />
-      <script is:inline set:html={gtagInit} />
-    </>
-  )
-}
+{import.meta.env.PROD && <script is:inline set:html={gtagInit} />}

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -37,48 +37,6 @@ const seo = {
   facebookAppId: facebookAppId ?? "",
 };
 
-const gtagId = "G-F1N7VJ0ZX9";
-// gtag.js measures the page as soon as it evaluates (it reads document/viewport
-// geometry to set up scroll tracking). Pulling it in with `async` from <head>
-// meant that read landed while the document was still being parsed and styled,
-// so it forced a synchronous layout of the whole page -- ~70ms of the "forced
-// reflow" the DevTools performance panel reports.
-//
-// Only the dataLayer queue below has to run early: gtag() just pushes onto an
-// array and gtag.js replays whatever is queued the moment it arrives, so the
-// hit timestamps (`gtag('js', new Date())`) stay accurate no matter when the
-// library shows up. That lets the library itself wait until the page has
-// painted and the main thread goes idle, when layout is already clean and the
-// same measurement costs nothing.
-//
-// astro:after-swap fires on ClientRouter navigations only (not the initial
-// load, which gtag('config') already reports), after the new <title> is set.
-// The ClientRouter skips inline scripts it has already executed (matched on
-// their text), so this whole block runs once per full page load -- the
-// listener is never registered twice and the library is never re-requested.
-const gtagInit = `window.dataLayer = window.dataLayer || [];
-function gtag() { dataLayer.push(arguments); }
-gtag('js', new Date());
-gtag('config', '${gtagId}');
-document.addEventListener('astro:after-swap', function () {
-  gtag('event', 'page_view', { page_location: location.href, page_title: document.title });
-});
-(function () {
-  function load() {
-    var script = document.createElement('script');
-    script.async = true;
-    script.src = 'https://www.googletagmanager.com/gtag/js?id=${gtagId}';
-    document.head.appendChild(script);
-  }
-  function schedule() {
-    // the timeout bounds the wait on a main thread that never actually idles
-    if (window.requestIdleCallback) requestIdleCallback(load, { timeout: 2000 });
-    else setTimeout(load, 500);
-  }
-  if (document.readyState === 'complete') schedule();
-  else window.addEventListener('load', schedule, { once: true });
-})();`;
-
 // gatsby-plugin-manifest icon set
 const manifestIconSizes = [48, 72, 96, 144, 192, 256, 384, 512];
 
@@ -87,10 +45,10 @@ const manifestIconSizes = [48, 72, 96, 144, 192, 256, 384, 512];
 // every cross-origin subresource here (scripts, stylesheets, images) is fetched
 // in no-cors mode, so a crossorigin preconnect would sit unused. The only
 // CORS-fetched resources are the fonts, and those are same-origin.
-// www.googletagmanager.com is deliberately absent: gtag.js is now requested
-// from an idle callback after load (see above), long after the preconnected
-// socket would have been reclaimed, so warming it here would only take a
-// connection slot away from the resources that do load with the page.
+// www.googletagmanager.com is deliberately absent: gtag.js is requested from an
+// idle callback after load (see src/integrations/inline-scripts.ts), long after
+// the preconnected socket would have been reclaimed, so warming it here would
+// only take a connection slot away from the resources that do load with the page.
 const preconnectDomains = [
   // Buy Me a Coffee widget loader, then the widget's own assets
   "https://cdnjs.buymeacoffee.com",
@@ -165,6 +123,3 @@ const preconnectDomains = [
     />
   ))
 }
-
-{/* gatsby-plugin-google-gtag (head: true, production only) */}
-{import.meta.env.PROD && <script is:inline set:html={gtagInit} />}

--- a/src/integrations/inline-scripts.ts
+++ b/src/integrations/inline-scripts.ts
@@ -1,0 +1,163 @@
+import type { AstroIntegration } from "astro";
+
+/*
+ * The page-level inline scripts, previously written as `<script is:inline
+ * set:html={...}>` in Layout.astro and BaseHead.astro. `injectScript`
+ * emits them verbatim into the `<head>` of every page, which buys two things
+ * the component-authored form did not have:
+ *
+ *   - `security.csp` digests them automatically. Astro only hashes the scripts
+ *     it injected itself (plus the built client chunks), so an inline <script>
+ *     written in a component is invisible to it and would need a hand-kept
+ *     entry in `security.csp.scriptDirective.hashes` that silently breaks the
+ *     page the first time someone edits the script and forgets the hash.
+ *   - the ClientRouter's already-executed check matches inline scripts on their
+ *     text, and injected scripts are byte-identical on every page, so each of
+ *     these still runs exactly once per full page load and never re-registers
+ *     its listeners on a navigation.
+ *
+ * Injected scripts are appended after the stylesheet link at the end of <head>,
+ * later than where these used to sit. They are still classic scripts in <head>,
+ * so they all run before the body is parsed: the theme toggle below applies
+ * ahead of first paint even when the render-blocking stylesheet is slow, since
+ * the paint is waiting on that stylesheet too.
+ *
+ * The Buy Me a Coffee loader stays in Layout.astro's <body>: it is an external
+ * script that reads its own `data-*` attributes off `document.currentScript`,
+ * so it cannot become injected inline content.
+ */
+
+// starwind theme init (replaces @yamada-ui/core's getColorModeScript);
+// runs before paint so the initial render already has the right color mode
+const themeInitScript = `(function () {
+  function initTheme() {
+    var colorTheme = localStorage.getItem("colorTheme");
+    var prefersDark =
+      window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+    if (!colorTheme || colorTheme === "system") {
+      document.documentElement.classList.toggle("dark", prefersDark);
+    } else {
+      document.documentElement.classList.toggle("dark", colorTheme === "dark");
+    }
+  }
+  initTheme();
+  document.addEventListener("astro:after-swap", initTheme);
+})();`;
+
+// click handler for the code block copy button (src/lib/satteri-plugins.ts)
+const copyToClipboardScript = `window.copyCodeToClipboard = async (button, codeContainer) => {
+  if (button.textContent === "Copied") {
+    return;
+  }
+  navigator.clipboard.writeText(codeContainer.textContent || "");
+  button.classList.add("copied");
+  button.textContent = "Copied!";
+  await new Promise((resolve) => {
+    setTimeout(() => {
+      button.classList.remove("copied");
+      button.textContent = "Copy";
+      resolve("done");
+    }, 1500);
+  });
+};`;
+
+// the Buy Me a Coffee widget injects #bmc-wbtn into <body>, plus an
+// unlabelled overlay div (click-outside-to-close target) that wraps
+// #bmc-iframe and #bmc-close-btn; carry all of it over to the next document
+// so the ClientRouter swap doesn't drop it (the widget script itself only
+// ever runs once). Moving #bmc-iframe alone would detach it from the overlay
+// and silently break both the outside-click close and the close button.
+const bmcPersistScript = `document.addEventListener("astro:before-swap", (event) => {
+  const wbtn = document.getElementById("bmc-wbtn");
+  if (wbtn) event.newDocument.body.appendChild(wbtn);
+  const overlay = document.getElementById("bmc-iframe")?.parentElement;
+  if (overlay) event.newDocument.body.appendChild(overlay);
+});`;
+
+// the widget ships a close button (#bmc-close-btn) for the opened panel, but
+// its own script only reveals it below the 480px breakpoint (relies on
+// clicking outside the panel to close on wider screens); show/hide it on the
+// widget's own open/close clicks so a close button is always available.
+// This used to sit at the end of <body>, after the widget loader; from <head>
+// the readyState guard takes the DOMContentLoaded branch instead of running
+// immediately, which is when the widget's DOM exists either way.
+const bmcCloseButtonScript = `function initBmcCloseButton() {
+  const closeBtn = document.getElementById("bmc-close-btn");
+  const wbtn = document.getElementById("bmc-wbtn");
+  if (!closeBtn || !wbtn || closeBtn.dataset.closeButtonWired) return;
+  closeBtn.dataset.closeButtonWired = "true";
+  const overlay = closeBtn.parentElement;
+  wbtn.addEventListener("click", () => {
+    closeBtn.style.visibility = "visible";
+  });
+  overlay.addEventListener("click", () => {
+    closeBtn.style.visibility = "hidden";
+  });
+}
+if (document.readyState === "loading") {
+  window.addEventListener("DOMContentLoaded", initBmcCloseButton);
+} else {
+  initBmcCloseButton();
+}
+document.addEventListener("astro:page-load", initBmcCloseButton);`;
+
+const gtagId = "G-F1N7VJ0ZX9";
+
+// gtag.js measures the page as soon as it evaluates (it reads document/viewport
+// geometry to set up scroll tracking). Loading it with `async` from <head>
+// meant that read landed while the document was still being parsed and styled,
+// so it forced a synchronous layout of the whole page -- ~70ms of the "forced
+// reflow" the DevTools performance panel reports.
+//
+// Only the dataLayer queue below has to run early: gtag() just pushes onto an
+// array and gtag.js replays whatever is queued the moment it arrives, so the
+// hit timestamps (`gtag('js', new Date())`) stay accurate no matter when the
+// library shows up. That lets the library itself wait until the page has
+// painted and the main thread goes idle, when layout is already clean and the
+// same measurement costs nothing.
+//
+// astro:after-swap fires on ClientRouter navigations only (not the initial
+// load, which gtag('config') already reports), after the new <title> is set.
+const gtagInit = `window.dataLayer = window.dataLayer || [];
+function gtag() { dataLayer.push(arguments); }
+gtag('js', new Date());
+gtag('config', '${gtagId}');
+document.addEventListener('astro:after-swap', function () {
+  gtag('event', 'page_view', { page_location: location.href, page_title: document.title });
+});
+(function () {
+  function load() {
+    var script = document.createElement('script');
+    script.async = true;
+    script.src = 'https://www.googletagmanager.com/gtag/js?id=${gtagId}';
+    document.head.appendChild(script);
+  }
+  function schedule() {
+    // the timeout bounds the wait on a main thread that never actually idles
+    if (window.requestIdleCallback) requestIdleCallback(load, { timeout: 2000 });
+    else setTimeout(load, 500);
+  }
+  if (document.readyState === 'complete') schedule();
+  else window.addEventListener('load', schedule, { once: true });
+})();`;
+
+export default function inlineScripts(): AstroIntegration {
+  return {
+    name: "inline-scripts",
+    hooks: {
+      "astro:config:setup": ({ command, injectScript }) => {
+        // theme first: it is the only one that has to beat the first paint
+        injectScript("head-inline", themeInitScript);
+        injectScript("head-inline", copyToClipboardScript);
+        injectScript("head-inline", bmcPersistScript);
+        injectScript("head-inline", bmcCloseButtonScript);
+        // gatsby-plugin-google-gtag (head: true, production only). Injected
+        // content is not processed by Vite, so `import.meta.env.PROD` would
+        // survive into the browser as-is; gate on the command instead.
+        if (command === "build") {
+          injectScript("head-inline", gtagInit);
+        }
+      },
+    },
+  };
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -16,86 +16,16 @@ export interface Props {
 
 const { head = {} } = Astro.props;
 
-// starwind theme init (replaces @yamada-ui/core's getColorModeScript);
-// runs before paint so the initial render already has the right color mode
-const themeInitScript = `(function () {
-  function initTheme() {
-    var colorTheme = localStorage.getItem("colorTheme");
-    var prefersDark =
-      window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
-    if (!colorTheme || colorTheme === "system") {
-      document.documentElement.classList.toggle("dark", prefersDark);
-    } else {
-      document.documentElement.classList.toggle("dark", colorTheme === "dark");
-    }
-  }
-  initTheme();
-  document.addEventListener("astro:after-swap", initTheme);
-})();`;
-
-// click handler for the code block copy button (src/lib/satteri-plugins.ts)
-const copyToClipboardScript = `window.copyCodeToClipboard = async (button, codeContainer) => {
-  if (button.textContent === "Copied") {
-    return;
-  }
-  navigator.clipboard.writeText(codeContainer.textContent || "");
-  button.classList.add("copied");
-  button.textContent = "Copied!";
-  await new Promise((resolve) => {
-    setTimeout(() => {
-      button.classList.remove("copied");
-      button.textContent = "Copy";
-      resolve("done");
-    }, 1500);
-  });
-};`;
-
-// the Buy Me a Coffee widget injects #bmc-wbtn into <body>, plus an
-// unlabelled overlay div (click-outside-to-close target) that wraps
-// #bmc-iframe and #bmc-close-btn; carry all of it over to the next document
-// so the ClientRouter swap doesn't drop it (the widget script itself only
-// ever runs once). Moving #bmc-iframe alone would detach it from the overlay
-// and silently break both the outside-click close and the close button.
-const bmcPersistScript = `document.addEventListener("astro:before-swap", (event) => {
-  const wbtn = document.getElementById("bmc-wbtn");
-  if (wbtn) event.newDocument.body.appendChild(wbtn);
-  const overlay = document.getElementById("bmc-iframe")?.parentElement;
-  if (overlay) event.newDocument.body.appendChild(overlay);
-});`;
-
-// the widget ships a close button (#bmc-close-btn) for the opened panel, but
-// its own script only reveals it below the 480px breakpoint (relies on
-// clicking outside the panel to close on wider screens); show/hide it on the
-// widget's own open/close clicks so a close button is always available
-const bmcCloseButtonScript = `function initBmcCloseButton() {
-  const closeBtn = document.getElementById("bmc-close-btn");
-  const wbtn = document.getElementById("bmc-wbtn");
-  if (!closeBtn || !wbtn || closeBtn.dataset.closeButtonWired) return;
-  closeBtn.dataset.closeButtonWired = "true";
-  const overlay = closeBtn.parentElement;
-  wbtn.addEventListener("click", () => {
-    closeBtn.style.visibility = "visible";
-  });
-  overlay.addEventListener("click", () => {
-    closeBtn.style.visibility = "hidden";
-  });
-}
-if (document.readyState === "loading") {
-  window.addEventListener("DOMContentLoaded", initBmcCloseButton);
-} else {
-  initBmcCloseButton();
-}
-document.addEventListener("astro:page-load", initBmcCloseButton);`;
+// The page-level inline scripts (theme init, code-block copy handler, Buy Me a
+// Coffee persistence and close button) live in src/integrations/inline-scripts.ts
+// and are injected into <head> from there, so `security.csp` can digest them.
 ---
 
 <!doctype html>
 <html lang="ja">
   <head>
-    <script is:inline set:html={themeInitScript} />
     <BaseHead {...head} />
     <ClientRouter />
-    <script is:inline set:html={copyToClipboardScript} />
-    <script is:inline set:html={bmcPersistScript} />
   </head>
   <body>
     <div id="app-root">
@@ -142,6 +72,5 @@ document.addEventListener("astro:page-load", initBmcCloseButton);`;
       data-position="Right"
       data-x_margin="18"
       data-y_margin="18"></script>
-    <script is:inline set:html={bmcCloseButtonScript} />
   </body>
 </html>


### PR DESCRIPTION
gtag.js reads document and viewport geometry as soon as it evaluates, to
set up GA4's scroll tracking. Loading it with `async` from <head> meant
that read landed while the document was still being parsed and styled,
turning it into a synchronous layout of the whole page -- the ~70ms the
DevTools performance panel attributes to gtag/js under "forced reflow".

Only the dataLayer queue has to run early: gtag() pushes onto an array
and the library replays whatever is queued when it arrives, so the hit
timestamp from gtag('js', new Date()) stays accurate regardless of when
the library shows up. Keep the snippet inline in <head> and fetch the
library itself from requestIdleCallback after load, when layout is
already clean, with a 2s timeout to bound the wait on a main thread that
never idles.

Measured on a standalone page built from this repo's stylesheets and a
24-card article grid, 4x CPU throttling: the geometry read blocked for
98-150ms before and 0.2-1.5ms after, with the same dataLayer entries
replayed. The deferred read also sees the real document extent instead
of a not-yet-laid-out zero-height body, so scroll depth is measured
against the actual page.

Drop the www.googletagmanager.com preconnect along with it: the request
now happens long after the warmed socket would have been reclaimed, so
the hint only took a connection slot from resources that do load with
the page.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MLVdNC9w8uYzpxnB8rVUMq