### PR TITLE
fix(jsonld): prefix ListItem urls with a leading slash

### DIFF
--- a/src/lib/jsonld.ts
+++ b/src/lib/jsonld.ts
@@ -7,6 +7,18 @@ type SchemaType = Exclude<Thing, string>["@type"];
 /** a JSON-LD node; kept loose because the builder assembles it dynamically */
 export type JSONLD = Record<string, unknown> & { "@type": SchemaType };
 
+/**
+ * Absolute URL for a site-relative path. siteUrl carries no trailing slash, so a
+ * path without a leading one would otherwise be glued onto the host
+ * ("articles/x" -> "https://blog.miyamo.todayarticles/x").
+ */
+const absoluteUrl = (path?: string): string => {
+  if (!path) {
+    return `${siteMetadata.siteUrl}/`;
+  }
+  return `${siteMetadata.siteUrl}${path.startsWith("/") ? "" : "/"}${path}`;
+};
+
 interface BuildJSONLDParams {
   path?: string;
   type?: SchemaType;
@@ -47,7 +59,7 @@ export const buildJSONLD = ({
     jsonLD["@context"] = "https://schema.org";
   }
   if (withID) {
-    jsonLD["@id"] = path ? `${siteMetadata.siteUrl}${path}` : `${siteMetadata.siteUrl}/`;
+    jsonLD["@id"] = absoluteUrl(path);
   }
   if (headline) {
     jsonLD["headline"] = headline;
@@ -61,23 +73,23 @@ export const buildJSONLD = ({
   if (withMainEntityOfPage) {
     jsonLD["mainEntityOfPage"] = {
       "@type": type ?? "WebSite",
-      "@id": path ? `${siteMetadata.siteUrl}${path}` : siteMetadata.siteUrl,
+      "@id": absoluteUrl(path),
     };
   }
   if (withUrl) {
-    jsonLD["url"] = path ? `${siteMetadata.siteUrl}${path}` : `${siteMetadata.siteUrl}/`;
+    jsonLD["url"] = absoluteUrl(path);
   }
   if (image) {
     jsonLD["image"] = {
       "@type": "ImageObject",
-      url: `${siteMetadata.siteUrl}${image}`,
+      url: absoluteUrl(image),
     };
   }
   if (withAuthor) {
     jsonLD["author"] = {
       "@type": "Person",
       name: "miyamo2",
-      url: `${siteMetadata.siteUrl}/about/`,
+      url: absoluteUrl("/about"),
       sameAs: [
         "https://github.com/miyamo2",
         "https://zenn.dev/miyamo2",
@@ -96,7 +108,7 @@ export const buildJSONLD = ({
   if (withLogo) {
     jsonLD["logo"] = {
       "@type": "ImageObject",
-      url: `${siteMetadata.siteUrl}${siteMetadata.icon}`,
+      url: absoluteUrl(siteMetadata.icon),
       width: 65,
       height: 65,
     };

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -20,7 +20,7 @@ const jsonLDWebSite = buildWebSiteJSONLD();
 const jsonLDArticles = data.cards.map((card, i) =>
   buildJSONLD({
     type: "ListItem",
-    path: `articles/${card.id}/`,
+    path: `/articles/${card.id}`,
     withUrl: true,
     attributes: {
       position: i + 1,

--- a/src/pages/pages/[page].astro
+++ b/src/pages/pages/[page].astro
@@ -30,7 +30,7 @@ const jsonLDWebSite = buildWebSiteJSONLD();
 const jsonLDArticles = data.cards.map((card, i) =>
   buildJSONLD({
     type: "ListItem",
-    path: `articles/${card.id}/`,
+    path: `/articles/${card.id}`,
     withUrl: true,
     attributes: {
       position: i + 1,

--- a/src/pages/tags/[tag]/[page].astro
+++ b/src/pages/tags/[tag]/[page].astro
@@ -31,7 +31,7 @@ const jsonLDWebSite = buildWebSiteJSONLD();
 const jsonLDArticles = data.cards.map((card, i) =>
   buildJSONLD({
     type: "ListItem",
-    path: `articles/${card.id}`,
+    path: `/articles/${card.id}`,
     withUrl: true,
     attributes: {
       position: i + 1,

--- a/src/pages/tags/[tag]/index.astro
+++ b/src/pages/tags/[tag]/index.astro
@@ -27,7 +27,7 @@ const jsonLDWebSite = buildWebSiteJSONLD();
 const jsonLDArticles = data.cards.map((card, i) =>
   buildJSONLD({
     type: "ListItem",
-    path: `articles/${card.id}`,
+    path: `/articles/${card.id}`,
     withUrl: true,
     attributes: {
       position: i + 1,

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -11,7 +11,7 @@ const path = "/tags";
 const jsonLDTags = tagSummaries.map((tag, i) =>
   buildJSONLD({
     type: "ListItem",
-    path: `tags/${tag.cursor}/`,
+    path: `/tags/${tag.cursor}`,
     withUrl: true,
     attributes: {
       position: i + 1,


### PR DESCRIPTION
The article/tag ListItem entries on the list pages passed paths without a
leading slash ("articles/{id}/"), and siteUrl carries no trailing one, so
they were concatenated into the host: "https://blog.miyamo.todayarticles/{id}/".

Add the missing slash at the call sites, align the item urls with the
canonical form the same pages emit for og:url (no trailing slash), and route
every url in the builder through a helper that normalizes the leading slash
so the same mistake can't produce an off-site URL again.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CeNtGAYNuRZQDQ9vWFkEd4