### PR TITLE
perf(search): fetch the algolia panel on intent instead of on page load

### DIFF
--- a/src/components/search/Search.astro
+++ b/src/components/search/Search.astro
@@ -7,7 +7,8 @@ import "./Search.css";
 
 /**
  * Algolia search, previously react-instantsearch inside a Yamada UI modal.
- * The markup is static; `./search.ts` wires the querying and result rendering.
+ * The markup is static; `./search.ts` wires the querying and result rendering
+ * and is fetched on demand (see the bootstrap script at the bottom).
  * This component is rendered twice by Header.astro (mobile / desktop), so every
  * hook below is scoped to the `.algolia-search` wrapper instead of an id.
  */
@@ -87,5 +88,37 @@ import "./Search.css";
 </Dialog>
 
 <script>
-  import "./search";
+  /*
+   * `./search` pulls in the Algolia client on top of the panel logic, which made
+   * it the largest same-origin chunk on the page (~8 KiB) even though most visits
+   * never open the panel -- and, being a module script in <head>, it sat on the
+   * critical request chain of every page. Splitting it behind a dynamic import
+   * takes those bytes out of the page load entirely and fetches them on the first
+   * sign that someone is heading for the search button.
+   */
+  let panel: Promise<unknown> | null = null;
+
+  const loadPanel = (): Promise<unknown> => (panel ??= import("./search"));
+
+  const onSearchIntent = (event: Event): void => {
+    const target = event.target;
+    if (target instanceof Element && target.closest(".algolia-search")) {
+      void loadPanel();
+    }
+  };
+
+  /*
+   * Delegated from `document` so this survives ClientRouter navigations: the
+   * listeners outlive every swap, and this script (like all injected/bundled
+   * module scripts) is only executed once per full page load anyway.
+   *
+   * pointerover and focusin both land before the click that opens the dialog, so
+   * the chunk is usually already parsed by the time the panel is visible. The
+   * capture-phase click is the fallback for input that reaches the trigger
+   * without either -- the panel adopts an already-open dialog on init, so losing
+   * that race only delays the input focus by the length of the fetch.
+   */
+  document.addEventListener("pointerover", onSearchIntent, { passive: true });
+  document.addEventListener("focusin", onSearchIntent);
+  document.addEventListener("click", onSearchIntent, { capture: true });
 </script>

--- a/src/components/search/search.ts
+++ b/src/components/search/search.ts
@@ -212,6 +212,20 @@ class SearchPanel {
     observer.observe(this.dialog, { attributes: true, attributeFilter: ["open"] });
   }
 
+  /**
+   * The module is fetched on the first sign of search intent (see Search.astro),
+   * so the dialog can already be open -- and can already hold typed text -- by the
+   * time the panel wires itself up. The observer above only reports later
+   * transitions of the `open` attribute, so catch up with the state the markup is
+   * already in instead of waiting for the next open.
+   */
+  public adoptCurrentState(): void {
+    if (!this.dialog.open) return;
+    this.clearButton.hidden = this.input.value.length === 0;
+    requestAnimationFrame(() => this.input.focus({ preventScroll: true }));
+    if (this.input.value.trim() !== "") void this.search(true);
+  }
+
   private cancelPending(): void {
     if (this.debounceId !== null) {
       clearTimeout(this.debounceId);
@@ -412,7 +426,7 @@ const setupSearchPanels = (): void => {
     if (initialized.has(root)) return;
     initialized.add(root);
     try {
-      new SearchPanel(root);
+      new SearchPanel(root).adoptCurrentState();
     } catch (error) {
       console.error(error);
     }


### PR DESCRIPTION
`./search` bundles the Algolia lite client with the panel logic, which made
it the largest same-origin chunk the site ships (~8 KiB transferred). It was
imported straight from Search.astro's component script, so every page load --
on a header that renders the component twice -- put it on the critical
request chain for a panel most visits never open.

Split it behind a dynamic import triggered by the first pointerover, focusin
or click that lands inside `.algolia-search`. The listeners are delegated
from `document` so they outlive ClientRouter swaps, and the two intent events
both fire before the click that opens the dialog, so the chunk is normally
parsed by the time the panel is visible.

When that race is lost the dialog can already be open, and can already hold
typed text, before the panel wires itself up -- its MutationObserver only
reports later transitions of `open`. SearchPanel.adoptCurrentState() catches
up with the markup as found: it focuses the input and runs whatever query is
already typed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FgAzq6tHQ6v9jjbhkpwN6X