### PR TITLE
feat(sitemap): announce article updates and drop redirect URLs

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -11,6 +11,7 @@ import { imagePlaceholderService } from "@miyamo2/astro-image-placeholder";
 import { remoteImageStaging } from "./integrations/remote-image-staging";
 import { inlineScripts } from "./integrations/inline-scripts";
 import { jsonld } from "./integrations/jsonld";
+import { lastmodSerializer } from "./integrations/sitemap-lastmod";
 import {
   headingAnchorPlugin,
   plainTextMdastPlugin,
@@ -132,7 +133,15 @@ export default defineConfig({
       url: env.BLOG_API_MIYAMO_TODAY_URL ?? "",
       token: env.BLOG_API_MIYAMO_TODAY_TOKEN ?? "",
     }),
-    sitemap(),
+    sitemap({
+      // /pages/1 and /tags/{tag}/1 are 301s to / and /tags/{tag} (the routes
+      // redirect themselves), so listing them only earns one "page with
+      // redirect" per tag in Search Console
+      filter: (page) => !/\/(?:pages|tags\/[^/]+)\/1\/?$/.test(new URL(page).pathname),
+      // without this every <url> is a bare <loc> and nothing tells a crawler
+      // an article was edited
+      serialize: lastmodSerializer(),
+    }),
     algoliaIndex({
       appId: env.PUBLIC_ALGOLIA_APP_ID,
       apiKey: env.ALGOLIA_ADMIN_KEY,

--- a/integrations/sitemap-lastmod/index.ts
+++ b/integrations/sitemap-lastmod/index.ts
@@ -1,0 +1,56 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import type { SitemapItem } from "@astrojs/sitemap";
+
+/** path (no trailing slash) -> ISO 8601 date of the newest article on that page */
+export type LastmodStore = Record<string, string>;
+
+/**
+ * Where the page build hands its per-page `lastmod` dates to @astrojs/sitemap.
+ *
+ * @astrojs/sitemap's `serialize` is configured in astro.config.ts, which runs
+ * as plain node and cannot import `astro:content` -- so it never sees the
+ * article dates the content layer loaded. src/lib/content.ts writes them here
+ * while the pages render, and `lastmodSerializer()` reads them back at
+ * `astro:build:done`, by which point every page has been generated.
+ *
+ * It lives in the astro cache dir (`cacheDir` in astro.config.ts): it is a
+ * build intermediate, so it must not land in `dist/` and get synced to S3.
+ */
+const STORE_PATH = resolve(process.cwd(), ".cache/sitemap-lastmod.json");
+
+/** `/about/` and `/about` are the same page; the store is keyed by the latter */
+const normalizePath = (pathname: string): string =>
+  pathname.length > 1 ? pathname.replace(/\/+$/, "") : pathname;
+
+export const writeLastmods = async (lastmods: LastmodStore): Promise<void> => {
+  await mkdir(dirname(STORE_PATH), { recursive: true });
+  await writeFile(STORE_PATH, JSON.stringify(lastmods), "utf8");
+};
+
+/**
+ * `serialize` for @astrojs/sitemap: stamps each URL with the date of the
+ * newest article it shows.
+ *
+ * Google is the only consumer that reads `lastmod`, and it stops trusting the
+ * field entirely once it catches a site reporting dates that did not happen --
+ * so a page with nothing dateable behind it (/about, whose content is the live
+ * GitHub profile) is left without one rather than given the build time.
+ */
+export const lastmodSerializer = (): ((item: SitemapItem) => Promise<SitemapItem>) => {
+  let store: Promise<LastmodStore> | undefined;
+  const load = (): Promise<LastmodStore> => {
+    // no store means no page ever rendered (or a build that failed earlier);
+    // a sitemap without lastmod is still valid, so degrade instead of throwing
+    store ??= readFile(STORE_PATH, "utf8").then(
+      (raw) => JSON.parse(raw) as LastmodStore,
+      () => ({})
+    );
+    return store;
+  };
+  return async (item) => {
+    const lastmods = await load();
+    const lastmod = lastmods[normalizePath(new URL(item.url).pathname)];
+    return lastmod ? { ...item, lastmod } : item;
+  };
+};

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Allow: /
-Sitemap: https://blog.miyamo.today/sitemap-0.xml
+Sitemap: https://blog.miyamo.today/sitemap-index.xml

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -11,6 +11,7 @@ import {
 } from "./images";
 import { optimizeLinkCardImages } from "./link-card-images";
 import { PER_PAGE, siteMetadata } from "./site";
+import { writeLastmods, type LastmodStore } from "../../integrations/sitemap-lastmod";
 
 interface TagVM {
   id: string;
@@ -128,6 +129,19 @@ const byIdDesc = (a: { id: string }, b: { id: string }): number => {
 };
 
 const range = (start: number, end: number) => [...Array(end - start + 1)].map((_, i) => start + i);
+
+/**
+ * `lastmod` for a page that lists articles: the newest of the articles it
+ * shows, so a list page re-announces itself exactly when its contents change.
+ */
+const latestUpdatedAt = (articles: RenderedArticle[]): string | undefined =>
+  articles.reduce<string | undefined>(
+    // ISO 8601 UTC strings from toISOString() are fixed-width, so they sort
+    // lexicographically in date order
+    (latest, article) =>
+      latest === undefined || article.updatedAt > latest ? article.updatedAt : latest,
+    undefined
+  );
 
 const toCard = (rendered: RenderedArticle): ArticleCardVM => {
   return {
@@ -314,6 +328,39 @@ const buildContent = async (): Promise<Content> => {
     };
   });
   await writeRecords(algoliaRecords);
+
+  // ---- sitemap lastmod ----
+  // Handed to @astrojs/sitemap's serialize(); see integrations/sitemap-lastmod
+  // for why it travels through a file rather than an import.
+  const lastmods: LastmodStore = {};
+  const articlesOf = (page: ArticleListPageVM): RenderedArticle[] =>
+    page.cards.map((card) => rendered.get(card.id)!);
+  const setLastmod = (path: string, articles: RenderedArticle[]): void => {
+    const lastmod = latestUpdatedAt(articles);
+    if (lastmod) {
+      lastmods[path] = lastmod;
+    }
+  };
+  for (const detail of details) {
+    lastmods[`/articles/${detail.id}`] = detail.updatedAt;
+  }
+  for (const listPage of listPages) {
+    // page 1 is "/" itself -- /pages/1 exists only to redirect there, and the
+    // sitemap filters it out (see astro.config.ts)
+    const path = listPage.currentPage === 1 ? "/" : `/pages/${listPage.currentPage}`;
+    setLastmod(path, articlesOf(listPage));
+  }
+  for (const taggedPage of taggedPages) {
+    // /tags/{tag}/1 redirects to /tags/{tag}, same as above
+    const path =
+      taggedPage.currentPage === 1
+        ? `/tags/${taggedPage.tagId}`
+        : `/tags/${taggedPage.tagId}/${taggedPage.currentPage}`;
+    setLastmod(path, articlesOf(taggedPage));
+  }
+  // the tag list shows every tag's article count, so any article can move it
+  setLastmod("/tags", [...rendered.values()]);
+  await writeLastmods(lastmods);
 
   return {
     listPages,


### PR DESCRIPTION
The sitemap was emitting bare <loc> entries: nothing in it told a crawler
that an article had been edited, so re-indexing an update was left to
whenever Google happened to re-crawl. The dates were already loaded --
articles carry updatedAt -- they just had no way to reach the sitemap,
since @astrojs/sitemap is configured from astro.config.ts, which runs as
plain node and cannot import astro:content.

The page build now writes a path -> date map to the astro cache dir and
the sitemap's serialize() reads it back at astro:build:done, by which
point every page has rendered. A list page takes the newest date among
the articles it shows, so it re-announces itself exactly when its
contents change. /about is left without one rather than stamped with the
build time: Google stops trusting lastmod entirely once it catches dates
that did not happen.

Also drops /pages/1 and /tags/{tag}/1 from the sitemap -- both routes
301 to / and /tags/{tag} respectively, so listing them earned one "page
with redirect" per tag in Search Console and nothing else. changefreq
and priority are deliberately still absent; Google ignores both.

robots.txt now points at sitemap-index.xml instead of sitemap-0.xml. The
entry limit is 45,000 so there is only one chunk today, but the moment a
sitemap-1.xml appears, crawlers arriving via robots.txt would never see
it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012aFZm3i6BXS1rEJftj2xMP