### PR TITLE
Improve article layout and reading rhythm for long-form content

### DIFF
--- a/src/features/ArticleDetail/Recommend.css
+++ b/src/features/ArticleDetail/Recommend.css
@@ -53,3 +53,33 @@
 .recommend-card_created_inner {
   font-size: 0.8rem !important;
 }
+
+/* In the side nav the card is the only thing filling a ~330-380px column, so it
+ * can afford to breathe: the title wraps onto a second line instead of being
+ * clipped after one, and the text side gets real padding on every edge. */
+@media (min-width: 1200px) {
+  .recommend-card {
+    height: 170px !important;
+    grid-template-columns: 1fr 38%;
+  }
+
+  .recommend-card_title {
+    height: auto !important;
+    padding: 0.75rem 0.75rem 0 !important;
+    line-height: 1.4 !important;
+    -webkit-line-clamp: 2 !important;
+    line-clamp: 2 !important;
+  }
+
+  .recommend-card_description {
+    height: auto !important;
+    padding: 0.5rem 0.75rem 0 !important;
+    line-height: 1.5 !important;
+  }
+
+  .recommend-card_created {
+    height: auto !important;
+    padding: 0 0.75rem 0.75rem !important;
+    align-items: flex-end !important;
+  }
+}

--- a/src/features/ArticleDetail/TOC.astro
+++ b/src/features/ArticleDetail/TOC.astro
@@ -30,14 +30,11 @@ const calcDepth = (depth: number | null | undefined) => {
       Table of Contents
     </h2>
   </div>
-  <div class="side-toc w-full pt-2">
+  <div class="side-toc w-full pt-3">
     {
       headings?.map((heading) => (
         <a href={`#${heading?.id}`}>
-          <span
-            class="block w-full truncate pb-2"
-            style={`text-indent: ${calcDepth(heading?.depth)}em`}
-          >
+          <span class="block w-full pb-3" style={`padding-left: ${calcDepth(heading?.depth)}em`}>
             {heading?.value}
           </span>
         </a>

--- a/src/lib/link-card-images.ts
+++ b/src/lib/link-card-images.ts
@@ -19,7 +19,9 @@ const THUMBNAIL_HEIGHT = 140;
 // slot, DPR 1.75); 560w covers the widest desktop box (273px) at DPR 2
 const THUMBNAIL_WIDTHS = [160, 280, 448, 560];
 // the media box is 40% of the card below 768px and 30% above it; the card is
-// the content column, which stops growing at 1400px * 65% (article-detail.css)
+// the content column, which stops growing at ~894px -- the 1fr track left over
+// once the share rail, the side nav and the gutters are taken out of the 1400px
+// wrapper (article-detail.css)
 const THUMBNAIL_SIZES = `(min-width: 1200px) ${THUMBNAIL_WIDTH}px, (min-width: 768px) 30vw, 40vw`;
 const FAVICON_WIDTH = 14;
 const FAVICON_WIDTHS = [14, 28];

--- a/src/views/ArticleDetailPage.astro
+++ b/src/views/ArticleDetailPage.astro
@@ -68,13 +68,15 @@ const createdAt = format(new Date(data.createdAt ?? ""), "YYYY/MM/DD");
     </div>
     <div style="grid-area: rnav" class="contain-paint hidden h-full w-full self-start lg:block">
       <div class="h-full overflow-visible">
-        <div style="position: sticky; top: 71px;">
+        <div class="article-sidebar">
           <TOC headings={data.headings} />
-          <Recommend recommends={data.recommends} />
+          <div class="pt-8">
+            <Recommend recommends={data.recommends} />
+          </div>
         </div>
       </div>
     </div>
-    <div style="grid-area: content" class="scroll-offset w-full">
+    <div style="grid-area: content" class="scroll-offset w-full pt-6">
       <article>
         <div class="markdown-body w-full" set:html={data.html ?? ""} />
       </article>

--- a/src/views/article-detail.css
+++ b/src/views/article-detail.css
@@ -1,8 +1,6 @@
 
 .side-toc {
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 :root {
@@ -22,17 +20,24 @@
     "recommend recommend recommend";
   grid-template-columns: 1fr 1fr 1fr;
   @media (min-width: 1200px) {
+    /* the header (title/tags/date/hero) shares the content column so the whole
+       article reads as one measured column, with the share rail in the left
+       margin and the side nav to its right -- the header used to span all three
+       tracks, which left it hanging ~140px to the left of the body text */
     grid-template-areas:
-      "title title title"
-      "tag tag tag"
-      "date date date"
-      ". image ."
+      "lnav title rnav"
+      "lnav tag rnav"
+      "lnav date rnav"
+      "lnav image rnav"
       "lnav content rnav"
       "lnav comment rnav";
     justify-content: start;
     align-items: start;
     contain: paint;
-    grid-template-columns: 10% 65% 25%;
+    /* the share rail only ever holds one column of 32px buttons; the width it
+       used to take (10%) is given to the side nav and to real gutters instead */
+    grid-template-columns: 3rem minmax(0, 1fr) clamp(19rem, 27%, 24rem);
+    column-gap: 2.5rem;
   }
 }
 
@@ -47,9 +52,31 @@
   margin-top: 2rem;
   margin-bottom: 1rem;
   @media (min-width: 1200px) {
-    margin-top: 1rem;
-    margin-bottom: 1rem;
+    margin-top: 1.75rem;
+    margin-bottom: 1.75rem;
   }
+}
+
+/* the sticky side nav scrolls inside itself once the table of contents and the
+   recommendations together outgrow the viewport, so its tail stays reachable */
+.article-sidebar {
+  position: sticky;
+  top: 71px;
+  max-height: calc(100vh - 71px - 1rem);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+}
+
+.side-toc a {
+  display: block;
+}
+
+/* headings wrap onto as many lines as they need instead of being cut off at the
+   column edge; the depth indent is padding so continuation lines line up too */
+.side-toc span {
+  line-height: 1.6;
+  overflow-wrap: anywhere;
 }
 
 .markdown-body {
@@ -1088,4 +1115,46 @@
 
 .markdown-body > *:first-child > .heading-element:first-child {
   margin-top: 0 !important;
+}
+
+/* ---------- reading rhythm ----------
+ * Everything above is github-markdown-css, whose vertical rhythm is tuned for
+ * dense code review (line-height 1.5, 16px between blocks). Long-form Japanese
+ * prose needs more air, so loosen it here; the selectors are scoped to direct
+ * children so nested lists and table cells keep the tight defaults.
+ */
+.markdown-body {
+  line-height: 1.9;
+}
+
+.markdown-body > p,
+.markdown-body > blockquote,
+.markdown-body > ul,
+.markdown-body > ol,
+.markdown-body > dl,
+.markdown-body > table,
+.markdown-body > details {
+  margin-bottom: 1.5em;
+}
+
+.markdown-body > h1,
+.markdown-body > h2,
+.markdown-body > h3,
+.markdown-body > h4,
+.markdown-body > h5,
+.markdown-body > h6 {
+  margin-top: 2.3em;
+  margin-bottom: 0.8em;
+  line-height: 1.5;
+}
+
+.markdown-body > ul > li + li,
+.markdown-body > ol > li + li {
+  margin-top: 0.4em;
+}
+
+/* shiki emits its <pre> without a line-height of its own, so keep code listings
+   on the tight rhythm they had instead of inheriting the prose one */
+.markdown-body pre {
+  line-height: 1.5;
 }

--- a/src/views/article-detail.css
+++ b/src/views/article-detail.css
@@ -58,13 +58,14 @@
 }
 
 /* the sticky side nav scrolls inside itself once the table of contents and the
-   recommendations together outgrow the viewport, so its tail stays reachable */
+   recommendations together outgrow the viewport, so its tail stays reachable.
+   Scroll chaining is deliberately left at the default: containing it would trap
+   the wheel here once the nav bottoms out, instead of carrying on down the page */
 .article-sidebar {
   position: sticky;
   top: 71px;
   max-height: calc(100vh - 71px - 1rem);
   overflow-y: auto;
-  overscroll-behavior: contain;
   scrollbar-width: thin;
 }
 


### PR DESCRIPTION
## Summary
This PR restructures the article detail page layout to better accommodate long-form Japanese prose and improves the readability of the side navigation. The changes include adjusting the grid layout to align headers with body content, making the side navigation sticky with internal scrolling, and increasing line-height and spacing throughout the markdown content.

## Key Changes

- **Grid Layout Restructuring**: Modified the desktop grid template to place the article header (title, tags, date, hero image) within the content column instead of spanning all three columns. This aligns the header with the body text and eliminates a ~140px left offset.

- **Side Navigation Improvements**:
  - Made `.article-sidebar` sticky with `top: 71px` and internal scrolling via `max-height` and `overflow-y: auto`
  - Removed text truncation from `.side-toc` to allow table of contents headings to wrap naturally
  - Added `display: block` to `.side-toc a` and improved wrapping with `overflow-wrap: anywhere` on spans
  - Changed indent from `text-indent` to `padding-left` so continuation lines align properly

- **Reading Rhythm for Prose**:
  - Increased base `line-height` from 1.5 to 1.9 in `.markdown-body`
  - Adjusted block-level margins (paragraphs, lists, tables, etc.) to `1.5em` for better air
  - Increased heading top margin to `2.3em` and bottom margin to `0.8em`
  - Preserved tight `line-height: 1.5` for code blocks via `<pre>` selector

- **Column Sizing**: Changed grid template columns from `10% 65% 25%` to `3rem minmax(0, 1fr) clamp(19rem, 27%, 24rem)` with `2.5rem` column gap, providing fixed space for the share rail and flexible sizing for the side nav.

- **Recommendation Card Styling**: Updated card layout for the side nav context with adjusted height, padding, and line-clamping to allow titles to wrap onto two lines.

- **Spacing Adjustments**: Updated padding and margins throughout (e.g., `pt-6` on content div, `pt-8` before recommendations, adjusted heading margins).

## Notable Implementation Details

- Scroll chaining is deliberately left at default in the sticky sidebar to allow wheel events to continue down the page once the nav bottoms out
- The side nav width is now flexible (`clamp()`) to accommodate different viewport sizes while maintaining readability
- Comments in the CSS explain the rationale for layout changes and reading rhythm adjustments for long-form Japanese prose

https://claude.ai/code/session_018G4AnhgLmaGj67yvqgna3x