### PR TITLE
refactor(article): scope the side nav's scrollbar to the heading list

### DIFF
--- a/src/features/ArticleDetail/Recommend.astro
+++ b/src/features/ArticleDetail/Recommend.astro
@@ -12,7 +12,6 @@ interface Props {
   recommends?: ReadonlyArray<{
     readonly id: string;
     readonly title: string;
-    readonly excerpt: string;
     readonly createdAt: string;
     readonly tags: ReadonlyArray<{ readonly id: string; readonly name: string }>;
     readonly imageData: RemoteImageData | null;
@@ -32,8 +31,8 @@ const { recommends } = Astro.props;
   {
     recommends?.map((recommend) => (
       <a href={`/articles/${recommend?.id ?? ""}`}>
-        <div class="recommend-card grid">
-          <div style="grid-area: image" class="recommend-card_thumbnail">
+        <div class="recommend-card">
+          <div class="recommend-card_thumbnail">
             <RemoteImage
               image={recommend?.imageData}
               alt={`ArticleImage:${recommend?.id ?? ""}`}
@@ -42,22 +41,19 @@ const { recommends } = Astro.props;
               class="transform-scaleup-then-hover-img-container h-full"
             />
           </div>
-          <div style="grid-area: title" class="recommend-card_title">
-            <h3 class="text-lg font-bold">{recommend?.title ?? ""}</h3>
-          </div>
-          <div style="grid-area: desc" class="recommend-card_description">
-            <p class="text-xs">{recommend?.excerpt ?? ""}</p>
-          </div>
-          <div style="grid-area: date" class="recommend-card_created flex">
-            <p class="recommend-card_created_inner">
-              <FaIcon icon={faCalendarDay} class="mr-2" />
-              {format(new Date(recommend?.createdAt ?? "1970-01-01"), "YYYY/MM/DD")}
-            </p>
-            {recommend?.tags
-              ?.filter((tag) => tag)
-              .map((tag) => (
-                <span class="recommend-card_tag bg-tag">#{tag.name}</span>
-              ))}
+          <div class="recommend-card_body">
+            <h3 class="recommend-card_title">{recommend?.title ?? ""}</h3>
+            <div class="recommend-card_created">
+              <p class="recommend-card_created_inner">
+                <FaIcon icon={faCalendarDay} class="mr-2" />
+                {format(new Date(recommend?.createdAt ?? "1970-01-01"), "YYYY/MM/DD")}
+              </p>
+              {recommend?.tags
+                ?.filter((tag) => tag)
+                .map((tag) => (
+                  <span class="recommend-card_tag bg-tag">#{tag.name}</span>
+                ))}
+            </div>
           </div>
         </div>
       </a>

--- a/src/features/ArticleDetail/Recommend.astro
+++ b/src/features/ArticleDetail/Recommend.astro
@@ -14,6 +14,7 @@ interface Props {
     readonly title: string;
     readonly excerpt: string;
     readonly createdAt: string;
+    readonly tags: ReadonlyArray<{ readonly id: string; readonly name: string }>;
     readonly imageData: RemoteImageData | null;
   } | null> | null;
 }
@@ -31,7 +32,7 @@ const { recommends } = Astro.props;
   {
     recommends?.map((recommend) => (
       <a href={`/articles/${recommend?.id ?? ""}`}>
-        <div class="recommend-card mb-2 grid rounded-lg shadow-md dark:bg-[#121820]">
+        <div class="recommend-card grid">
           <div style="grid-area: image" class="recommend-card_thumbnail">
             <RemoteImage
               image={recommend?.imageData}
@@ -52,6 +53,11 @@ const { recommends } = Astro.props;
               <FaIcon icon={faCalendarDay} class="mr-2" />
               {format(new Date(recommend?.createdAt ?? "1970-01-01"), "YYYY/MM/DD")}
             </p>
+            {recommend?.tags
+              ?.filter((tag) => tag)
+              .map((tag) => (
+                <span class="recommend-card_tag bg-tag">#{tag.name}</span>
+              ))}
           </div>
         </div>
       </a>

--- a/src/features/ArticleDetail/Recommend.css
+++ b/src/features/ArticleDetail/Recommend.css
@@ -25,10 +25,13 @@
 }
 
 /* min-width:0 is what lets the title and the meta line ellipsise rather than
-   widening the row past the column */
+   widening the row past the column; the column layout is what lets the meta line
+   sit at the bottom of the row rather than wherever the title happens to end */
 .recommend-card_body {
   flex: 1 1 auto;
   min-width: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 /* two lines: three plus the meta line would not fit the 92px row */
@@ -51,7 +54,9 @@
   flex-wrap: nowrap;
   align-items: center;
   gap: 0.35rem;
-  margin-top: 0.4rem;
+  /* pinned to the bottom of the row, level with the foot of the thumbnail, so a
+     one-line title and a two-line one put the date in the same place */
+  margin-top: auto;
   overflow: hidden;
   -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 0.75rem), transparent);
   mask-image: linear-gradient(to right, #000 calc(100% - 0.75rem), transparent);

--- a/src/features/ArticleDetail/Recommend.css
+++ b/src/features/ArticleDetail/Recommend.css
@@ -54,32 +54,59 @@
   font-size: 0.8rem !important;
 }
 
-/* In the side nav the card is the only thing filling a ~330-380px column, so it
- * can afford to breathe: the title wraps onto a second line instead of being
- * clipped after one, and the text side gets real padding on every edge. */
+/* In the side nav these are a list, not cards: a 92px square thumbnail, a title
+ * free to run to three lines, and the date -- the shape Zenn gives its article
+ * rows. Dropping the excerpt is what buys the height back; as a card with one it
+ * stood 170px tall and three of them crowded the table of contents out of the
+ * column. Separation comes from the gap between rows instead of a card edge. */
 @media (min-width: 1200px) {
   .recommend-card {
-    height: 170px !important;
-    grid-template-columns: 1fr 38%;
+    height: auto !important;
+    grid-template-areas:
+      "image title"
+      "image date";
+    grid-template-columns: 92px minmax(0, 1fr);
+    grid-template-rows: auto auto;
+    column-gap: 1rem;
+    align-items: start;
+    margin-bottom: 1.5rem !important;
+    background: transparent !important;
+    box-shadow: none !important;
+    border-radius: 0 !important;
+  }
+
+  .recommend-card_thumbnail {
+    width: 92px !important;
+    height: 92px !important;
+    overflow: hidden !important;
+    border-radius: 0.5rem;
   }
 
   .recommend-card_title {
     height: auto !important;
-    padding: 0.75rem 0.75rem 0 !important;
-    line-height: 1.4 !important;
-    -webkit-line-clamp: 2 !important;
-    line-clamp: 2 !important;
+    padding: 0 !important;
+    -webkit-line-clamp: 3 !important;
+    line-clamp: 3 !important;
   }
 
+  .recommend-card_title h3 {
+    font-size: 1.05rem;
+    line-height: 1.5;
+  }
+
+  /* the excerpt is the whole reason the row was tall; the title carries it */
   .recommend-card_description {
-    height: auto !important;
-    padding: 0.5rem 0.75rem 0 !important;
-    line-height: 1.5 !important;
+    display: none !important;
   }
 
   .recommend-card_created {
     height: auto !important;
-    padding: 0 0.75rem 0.75rem !important;
-    align-items: flex-end !important;
+    padding: 0 !important;
+    margin-top: 0.4rem !important;
+    align-items: center !important;
+  }
+
+  .recommend-card_created_inner {
+    font-size: 0.72rem !important;
   }
 }

--- a/src/features/ArticleDetail/Recommend.css
+++ b/src/features/ArticleDetail/Recommend.css
@@ -1,68 +1,79 @@
-/* A recommendation is a row, not a card: a 92px square thumbnail on the left, a
- * title free to run to three lines beside it, and a meta line carrying the date
- * and the article's tags. Rows are separated by the gap between them rather than
- * by a card edge -- the shape Zenn gives its article lists.
+/* A recommendation is a row, not a card: a 92px square thumbnail on the left,
+ * the title beside it, and a meta line carrying the date and the article's tags.
+ * Rows are separated by the gap between them rather than by a card edge -- the
+ * shape Zenn gives its article lists. The same row is used in the side nav and
+ * under the article on narrow screens.
  *
- * The same shape is used in the side nav and under the article on narrow
- * screens. As a 150px card with a two-line excerpt, three of them took 610px of
- * the side nav and left the table of contents 38% of the column. */
+ * Every row is exactly as tall as its thumbnail whatever the title and tags
+ * happen to be, so the list never staggers: the title is clamped to two lines
+ * and the meta line never wraps, both ellipsising instead of growing. */
 .recommend-card {
-  width: 100% !important;
-  grid-template-areas:
-    "image title"
-    "image date";
-  grid-template-columns: 92px minmax(0, 1fr);
-  grid-template-rows: auto auto;
-  column-gap: 1rem;
-  align-items: start;
+  display: flex;
+  gap: 1rem;
+  width: 100%;
+  height: 92px;
+  overflow: hidden;
   margin-bottom: 1.5rem;
 }
 
 .recommend-card_thumbnail {
-  width: 92px !important;
-  height: 92px !important;
-  overflow: hidden !important;
+  flex: 0 0 92px;
+  width: 92px;
+  height: 92px;
+  overflow: hidden;
   border-radius: 0.5rem;
 }
 
-.recommend-card_title {
-  max-width: 100% !important;
-  overflow: hidden !important;
-  display: -webkit-box !important;
-  -webkit-box-orient: vertical !important;
-  -webkit-line-clamp: 3 !important;
-  line-clamp: 3 !important;
+/* min-width:0 is what lets the title and the meta line ellipsise rather than
+   widening the row past the column */
+.recommend-card_body {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
-.recommend-card_title h3 {
+/* two lines: three plus the meta line would not fit the 92px row */
+.recommend-card_title {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  overflow: hidden;
   font-size: 1.05rem;
+  font-weight: 700;
   line-height: 1.5;
 }
 
-/* the excerpt is what made the row tall; the three-line title carries it now */
-.recommend-card_description {
-  display: none !important;
-}
-
+/* one line that never wraps, so the row height cannot depend on the tag count.
+ * The fade over the last few pixels is what a tag clipped by the end of the line
+ * runs into, so the cut reads as "there is more" rather than as a broken chip */
 .recommend-card_created {
-  max-width: 100% !important;
-  margin-top: 0.4rem !important;
-  display: flex !important;
-  flex-wrap: wrap;
+  display: flex;
+  flex-wrap: nowrap;
   align-items: center;
   gap: 0.35rem;
+  margin-top: 0.4rem;
+  overflow: hidden;
+  -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 0.75rem), transparent);
+  mask-image: linear-gradient(to right, #000 calc(100% - 0.75rem), transparent);
 }
 
 .recommend-card_created_inner {
-  font-size: 0.72rem !important;
+  flex-shrink: 0;
+  font-size: 0.72rem;
   white-space: nowrap;
 }
 
 /* Decorative, not links -- the whole row is already an anchor, and an <a> inside
- * an <a> is not valid HTML. A tag long enough to fill the row is ellipsised
- * rather than allowed to push the meta line wider than the column. */
+ * an <a> is not valid HTML.
+ *
+ * Each chip keeps its natural width up to 9rem and ellipsises there, rather than
+ * shrinking to share the line: letting them all shrink turns a row holding one
+ * very long tag into a line of "#.." stubs. 9rem always fits the space the date
+ * leaves, so the first tag is readable whatever the others are; any that spill
+ * past the end of the line are clipped by the overflow above. */
 .recommend-card_tag {
-  max-width: 100%;
+  flex-shrink: 0;
+  max-width: 9rem;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -70,4 +81,9 @@
   padding: 1px 0.4rem;
   font-size: 0.68rem;
   line-height: 1.5;
+}
+
+/* past three there is not enough line left for a chip to say anything */
+.recommend-card_tag:nth-of-type(n + 4) {
+  display: none;
 }

--- a/src/features/ArticleDetail/Recommend.css
+++ b/src/features/ArticleDetail/Recommend.css
@@ -1,112 +1,73 @@
+/* A recommendation is a row, not a card: a 92px square thumbnail on the left, a
+ * title free to run to three lines beside it, and a meta line carrying the date
+ * and the article's tags. Rows are separated by the gap between them rather than
+ * by a card edge -- the shape Zenn gives its article lists.
+ *
+ * The same shape is used in the side nav and under the article on narrow
+ * screens. As a 150px card with a two-line excerpt, three of them took 610px of
+ * the side nav and left the table of contents 38% of the column. */
 .recommend-card {
-  overflow: hidden !important;
-  height: 150px !important;
   width: 100% !important;
-  isolation: isolate !important;
   grid-template-areas:
-    "title image"
-    "desc image"
-    ". image"
-    "date image";
-  grid-template-columns: 60% 40%;
+    "image title"
+    "image date";
+  grid-template-columns: 92px minmax(0, 1fr);
+  grid-template-rows: auto auto;
+  column-gap: 1rem;
+  align-items: start;
+  margin-bottom: 1.5rem;
 }
 
 .recommend-card_thumbnail {
-  height: 100% !important;
+  width: 92px !important;
+  height: 92px !important;
+  overflow: hidden !important;
+  border-radius: 0.5rem;
 }
 
 .recommend-card_title {
-  padding-top: 0.5rem !important;
-  padding-left: 0.5rem !important;
   max-width: 100% !important;
-  height: 2rem !important;
-  overflow: hidden !important;
-  -webkit-line-clamp: 1 !important;
-  line-clamp: 1 !important;
-  display: -webkit-inline-box !important;
-  -webkit-box-orient: vertical !important;
-}
-.recommend-card_description {
-  padding-left: 0.5rem !important;
-  height: 2rem !important;
-  max-width: 100% !important;
-  overflow: hidden !important;
-}
-.recommend-card_description p {
   overflow: hidden !important;
   display: -webkit-box !important;
   -webkit-box-orient: vertical !important;
-  -webkit-line-clamp: 2 !important;
-  line-clamp: 2 !important;
+  -webkit-line-clamp: 3 !important;
+  line-clamp: 3 !important;
 }
+
+.recommend-card_title h3 {
+  font-size: 1.05rem;
+  line-height: 1.5;
+}
+
+/* the excerpt is what made the row tall; the three-line title carries it now */
+.recommend-card_description {
+  display: none !important;
+}
+
 .recommend-card_created {
-  padding-left: 0.5rem !important;
-  height: 1.5rem !important;
   max-width: 100% !important;
-  overflow: hidden !important;
-  -webkit-line-clamp: 1 !important;
-  line-clamp: 1 !important;
-  display: -webkit-inline-box !important;
-  -webkit-box-orient: vertical !important;
+  margin-top: 0.4rem !important;
+  display: flex !important;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
 }
 
 .recommend-card_created_inner {
-  font-size: 0.8rem !important;
+  font-size: 0.72rem !important;
+  white-space: nowrap;
 }
 
-/* In the side nav these are a list, not cards: a 92px square thumbnail, a title
- * free to run to three lines, and the date -- the shape Zenn gives its article
- * rows. Dropping the excerpt is what buys the height back; as a card with one it
- * stood 170px tall and three of them crowded the table of contents out of the
- * column. Separation comes from the gap between rows instead of a card edge. */
-@media (min-width: 1200px) {
-  .recommend-card {
-    height: auto !important;
-    grid-template-areas:
-      "image title"
-      "image date";
-    grid-template-columns: 92px minmax(0, 1fr);
-    grid-template-rows: auto auto;
-    column-gap: 1rem;
-    align-items: start;
-    margin-bottom: 1.5rem !important;
-    background: transparent !important;
-    box-shadow: none !important;
-    border-radius: 0 !important;
-  }
-
-  .recommend-card_thumbnail {
-    width: 92px !important;
-    height: 92px !important;
-    overflow: hidden !important;
-    border-radius: 0.5rem;
-  }
-
-  .recommend-card_title {
-    height: auto !important;
-    padding: 0 !important;
-    -webkit-line-clamp: 3 !important;
-    line-clamp: 3 !important;
-  }
-
-  .recommend-card_title h3 {
-    font-size: 1.05rem;
-    line-height: 1.5;
-  }
-
-  /* the excerpt is the whole reason the row was tall; the title carries it */
-  .recommend-card_description {
-    display: none !important;
-  }
-
-  .recommend-card_created {
-    height: auto !important;
-    padding: 0 !important;
-    margin-top: 0.4rem !important;
-    align-items: center !important;
-  }
-
-  .recommend-card_created_inner {
-    font-size: 0.72rem !important;
-  }
+/* Decorative, not links -- the whole row is already an anchor, and an <a> inside
+ * an <a> is not valid HTML. A tag long enough to fill the row is ellipsised
+ * rather than allowed to push the meta line wider than the column. */
+.recommend-card_tag {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border-radius: 0.375rem;
+  padding: 1px 0.4rem;
+  font-size: 0.68rem;
+  line-height: 1.5;
 }

--- a/src/features/ArticleDetail/TOC.astro
+++ b/src/features/ArticleDetail/TOC.astro
@@ -23,7 +23,7 @@ const calcDepth = (depth: number | null | undefined) => {
 };
 ---
 
-<div class="w-full pl-[0.5em]">
+<div class="side-toc-block w-full pl-[0.5em]">
   <div class="w-full border-b backdrop-blur-md [writing-mode:horizontal-tb]">
     <h2 class="text-xl font-bold whitespace-nowrap">
       <FaIcon icon={faListUl} class="mr-2" />
@@ -34,7 +34,7 @@ const calcDepth = (depth: number | null | undefined) => {
     {
       headings?.map((heading) => (
         <a href={`#${heading?.id}`}>
-          <span class="block w-full pb-3" style={`padding-left: ${calcDepth(heading?.depth)}em`}>
+          <span class="block w-full" style={`padding-left: ${calcDepth(heading?.depth)}em`}>
             {heading?.value}
           </span>
         </a>

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -32,6 +32,7 @@ interface RecommendVM {
   title: string;
   excerpt: string;
   createdAt: string;
+  tags: TagVM[];
   imageData: RemoteImageData | null;
 }
 
@@ -269,6 +270,7 @@ const buildContent = async (): Promise<Content> => {
           title: rec.title,
           excerpt: excerptOf(rec.plainText, 140, true),
           createdAt: rec.createdAt,
+          tags: rec.tags,
           imageData: rec.recommendImage,
         })
       );

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -30,7 +30,6 @@ interface ArticleCardVM {
 interface RecommendVM {
   id: string;
   title: string;
-  excerpt: string;
   createdAt: string;
   tags: TagVM[];
   imageData: RemoteImageData | null;
@@ -268,7 +267,6 @@ const buildContent = async (): Promise<Content> => {
         (rec): RecommendVM => ({
           id: rec.id,
           title: rec.title,
-          excerpt: excerptOf(rec.plainText, 140, true),
           createdAt: rec.createdAt,
           tags: rec.tags,
           imageData: rec.recommendImage,

--- a/src/views/ArticleDetailPage.astro
+++ b/src/views/ArticleDetailPage.astro
@@ -70,7 +70,7 @@ const createdAt = format(new Date(data.createdAt ?? ""), "YYYY/MM/DD");
       <div class="h-full overflow-visible">
         <div class="article-sidebar">
           <TOC headings={data.headings} />
-          <div class="pt-8">
+          <div class="recommend-block pt-8">
             <Recommend recommends={data.recommends} />
           </div>
         </div>

--- a/src/views/ArticleDetailPage.astro
+++ b/src/views/ArticleDetailPage.astro
@@ -61,7 +61,7 @@ const createdAt = format(new Date(data.createdAt ?? ""), "YYYY/MM/DD");
     </div>
     <div style="grid-area: lnav" class="hidden h-full self-end lg:block">
       <div class="h-full w-full overflow-visible">
-        <div style="position: sticky; top: 71px;">
+        <div class="article-share-rail">
           <ShareButtons title={data.title ?? ""} url={url} stackType="v" buttonSize={32} />
         </div>
       </div>

--- a/src/views/article-detail.css
+++ b/src/views/article-detail.css
@@ -8,6 +8,11 @@
 }
 
 .article-detail {
+  /* where the sticky rails come to rest: clear of the 70px fixed site header,
+     plus enough of a gap that they do not read as glued to it. Both rails
+     share it so they always line up */
+  --article-sticky-top: 5.5rem;
+
   grid-template-areas:
     "title title title"
     "tag tag tag"
@@ -68,12 +73,17 @@
    without it those cards would be stranded below the fold. */
 .article-sidebar {
   position: sticky;
-  top: 71px;
-  max-height: calc(100vh - 71px - 1rem);
+  top: var(--article-sticky-top);
+  max-height: calc(100vh - var(--article-sticky-top) - 1rem);
   display: flex;
   flex-direction: column;
   overflow-y: auto;
   scrollbar-width: thin;
+}
+
+.article-share-rail {
+  position: sticky;
+  top: var(--article-sticky-top);
 }
 
 .side-toc-block {

--- a/src/views/article-detail.css
+++ b/src/views/article-detail.css
@@ -12,6 +12,10 @@
      plus enough of a gap that they do not read as glued to it. Both rails
      share it so they always line up */
   --article-sticky-top: 5.5rem;
+  /* how tall the side nav may get, and how much of that the heading list is
+     guaranteed once the two blocks start competing for it */
+  --article-sidebar-max: calc(100vh - var(--article-sticky-top) - 1rem);
+  --article-toc-min: 14rem;
 
   grid-template-areas:
     "title title title"
@@ -63,22 +67,16 @@
 }
 
 /* The side nav is capped at the viewport and lays its two blocks out as a flex
-   column, so the only thing that ever scrolls is the list of headings: the
-   recommendations keep their natural height and the heading list takes whatever
-   is left. Scroll chaining is deliberately left at the default -- containing it
-   would trap the wheel here once the list bottoms out, instead of carrying on
-   down the page.
-   The overflow on the nav itself is a fallback, not the normal path: it only
-   engages when the recommendations alone are taller than the viewport, and
-   without it those cards would be stranded below the fold. */
+   column, so the nav itself never scrolls -- each block owns its own overflow.
+   Scroll chaining is deliberately left at the default: containing it would trap
+   the wheel in a block once it bottoms out, instead of carrying on down the
+   page. */
 .article-sidebar {
   position: sticky;
   top: var(--article-sticky-top);
-  max-height: calc(100vh - var(--article-sticky-top) - 1rem);
+  max-height: var(--article-sidebar-max);
   display: flex;
   flex-direction: column;
-  overflow-y: auto;
-  scrollbar-width: thin;
 }
 
 .article-share-rail {
@@ -89,11 +87,12 @@
 .side-toc-block {
   display: flex;
   flex-direction: column;
-  /* gives its space up to the recommendations, but never below the point where
-     the list stops being a usable nav -- past that the fallback overflow on
-     .article-sidebar takes over rather than leaving a one-line peephole */
+  /* sized by its content and free to shrink; the floor it needs is expressed as
+     a max-height on the recommendations instead of a min-height here, because a
+     min-height also applies when the list is *shorter* than it and would pad a
+     three-entry table of contents out with blank space */
   flex: 0 1 auto;
-  min-height: 14rem;
+  min-height: 0;
 }
 
 .side-toc {
@@ -106,8 +105,14 @@
   border-bottom: 1px solid var(--border);
 }
 
+/* keeps its natural height -- but never takes so much of the nav that the
+   heading list is squeezed below --article-toc-min. As a max-height this only
+   binds when the cards genuinely do not fit, so a short list is never padded */
 .article-sidebar > .recommend-block {
   flex: 0 0 auto;
+  max-height: calc(var(--article-sidebar-max) - var(--article-toc-min));
+  overflow-y: auto;
+  scrollbar-width: thin;
 }
 
 .side-toc a {

--- a/src/views/article-detail.css
+++ b/src/views/article-detail.css
@@ -57,25 +57,63 @@
   }
 }
 
-/* the sticky side nav scrolls inside itself once the table of contents and the
-   recommendations together outgrow the viewport, so its tail stays reachable.
-   Scroll chaining is deliberately left at the default: containing it would trap
-   the wheel here once the nav bottoms out, instead of carrying on down the page */
+/* The side nav is capped at the viewport and lays its two blocks out as a flex
+   column, so the only thing that ever scrolls is the list of headings: the
+   recommendations keep their natural height and the heading list takes whatever
+   is left. Scroll chaining is deliberately left at the default -- containing it
+   would trap the wheel here once the list bottoms out, instead of carrying on
+   down the page.
+   The overflow on the nav itself is a fallback, not the normal path: it only
+   engages when the recommendations alone are taller than the viewport, and
+   without it those cards would be stranded below the fold. */
 .article-sidebar {
   position: sticky;
   top: 71px;
   max-height: calc(100vh - 71px - 1rem);
+  display: flex;
+  flex-direction: column;
   overflow-y: auto;
   scrollbar-width: thin;
 }
 
-.side-toc a {
-  display: block;
+.side-toc-block {
+  display: flex;
+  flex-direction: column;
+  /* gives its space up to the recommendations, but never below the point where
+     the list stops being a usable nav -- past that the fallback overflow on
+     .article-sidebar takes over rather than leaving a one-line peephole */
+  flex: 0 1 auto;
+  min-height: 14rem;
 }
 
-/* headings wrap onto as many lines as they need instead of being cut off at the
-   column edge; the depth indent is padding so continuation lines line up too */
+.side-toc {
+  flex: 0 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  /* bookends the header rule, so a list cut off mid-entry reads as a bounded
+     box that scrolls rather than as text that just stops */
+  border-bottom: 1px solid var(--border);
+}
+
+.article-sidebar > .recommend-block {
+  flex: 0 0 auto;
+}
+
+.side-toc a {
+  display: block;
+  padding-bottom: 0.75rem;
+}
+
+/* two lines per heading, ellipsised past that: long headings stay readable
+   without letting one of them eat the column. The depth indent is padding so
+   the second line lines up with the first */
 .side-toc span {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  overflow: hidden;
   line-height: 1.6;
   overflow-wrap: anywhere;
 }


### PR DESCRIPTION
Follow-up to #77. Based on that branch, so the diff here is only the side-nav scrolling change; GitHub will retarget this to the default branch once #77 merges.

## Why

#77 capped the whole side nav and scrolled it as one box, so the scrollbar spanned the table of contents and the recommendation cards alike — it reads as the sidebar itself sliding around rather than as one list scrolling.

Zenn caps only its table-of-contents card (`max-height: calc(100vh - 50px)`, `overflow: auto`) and clamps each entry to two lines, so the scroll is visibly a property of that one list. This change does the same.

## What

- The nav is a flex column bounded by the viewport: the recommendations keep their natural height (`flex: 0 0 auto`) and the heading list takes what is left (`flex: 0 1 auto; min-height: 0`), so the list is the only thing that ever scrolls. No reserved-height constant — the loader emits up to three recommendation cards (`limit: 3` in `src/content.config.ts`) and flex works out the split whatever the count.
- Entries are clamped to two lines (`-webkit-line-clamp: 2`) instead of wrapping without limit, so one long heading can't take over the column.
- The list gets a bottom rule, bookending the header rule, so a list cut off mid-entry reads as a bounded box rather than as text that just stops.
- The overflow on the nav itself stays as a fallback, with a 14rem floor on the list so it degrades into a short list rather than a one-line peephole.

## Measured (1600px wide, 18 headings with long titles, 3 recommendation cards)

| viewport height | heading list | scrollbar on the list | scrollbar on the nav | all 3 cards visible |
|---|---|---|---|---|
| 1320px | 594px | yes | no | yes |
| 960px (1080p screen) | 234px | yes | no | yes |
| 780px | 195px | yes | yes (fallback) | reachable by scrolling |
| 648px | 195px | yes | yes (fallback) | reachable by scrolling |

At 960px of viewport height and above — the common desktop case — only the heading list scrolls and every recommendation card stays on screen.

## Known limit

Three recommendation cards occupy ~610px, which is most of the nav's budget on a short screen. Below roughly 850px of viewport height there is no arrangement that leaves the heading list meaningful space without touching the cards, so the nav-level fallback engages there. Shrinking the sidebar cards, showing fewer of them, or moving the recommendations out of the sticky nav and under the article would remove that case; none of those are in this PR.

## Verification

No dev server: the `@miyamo2/*` packages live on GitHub Packages and the token available in that session lacked `packages:read`. Checked instead by rendering the real stylesheets against a static reproduction of the article-detail markup in Chromium — grid geometry, sticky offsets through a full scroll, scroll chaining out of the nav, and the flex split at the four viewport heights above. Fonts (UDEVGothic) and giscus are not part of that reproduction, so the sticky offsets are worth a look on the real site once deployed.

---
_Generated by [Claude Code](https://claude.ai/code/session_018G4AnhgLmaGj67yvqgna3x)_