### PR TITLE
Minify injected inline scripts and stylesheets in production builds

### DIFF
--- a/integrations/inline-scripts/index.ts
+++ b/integrations/inline-scripts/index.ts
@@ -1,4 +1,5 @@
 import type { AstroIntegration } from "astro";
+import { transformWithEsbuild } from "vite";
 
 /*
  * The page-level inline scripts, previously written as `<script is:inline
@@ -145,17 +146,31 @@ export const inlineScripts = (): AstroIntegration => {
   return {
     name: "inline-scripts",
     hooks: {
-      "astro:config:setup": ({ command, injectScript }) => {
+      "astro:config:setup": async ({ command, injectScript }) => {
+        // Injected content never reaches Vite, so these ship to every page
+        // exactly as written above -- ~2.8kB of indentation and comments per
+        // page. Minify them here instead, on builds only, so `astro dev` still
+        // steps through the source (which is also when `?inline` stylesheets
+        // stay unminified).
+        const inject =
+          command === "build"
+            ? async (code: string) =>
+                injectScript(
+                  "head-inline",
+                  (await transformWithEsbuild(code, "inline-script.js", { minify: true })).code
+                )
+            : async (code: string) => injectScript("head-inline", code);
+
         // theme first: it is the only one that has to beat the first paint
-        injectScript("head-inline", themeInitScript);
-        injectScript("head-inline", copyToClipboardScript);
-        injectScript("head-inline", bmcPersistScript);
-        injectScript("head-inline", bmcCloseButtonScript);
+        await inject(themeInitScript);
+        await inject(copyToClipboardScript);
+        await inject(bmcPersistScript);
+        await inject(bmcCloseButtonScript);
         // gatsby-plugin-google-gtag (head: true, production only). Injected
         // content is not processed by Vite, so `import.meta.env.PROD` would
         // survive into the browser as-is; gate on the command instead.
         if (command === "build") {
-          injectScript("head-inline", gtagInit);
+          await inject(gtagInit);
         }
       },
     },

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -3,7 +3,11 @@ import type { JsonLdNode } from "@miyamo2/astro-jsonld";
 import JsonLd from "@miyamo2/astro-jsonld/JsonLd.astro";
 import { absoluteUrl } from "virtual:jsonld";
 import { siteMetadata } from "../lib/site";
-import scrollDrivenCss from "../styles/scroll-driven.css?raw";
+// `?inline` rather than `?raw`: both hand the stylesheet over as a string
+// without adding it to the CSS bundle, but `?inline` is the one that goes
+// through Vite's CSS pipeline, so a build inlines it minified (`?raw` shipped
+// the comments and indentation to every page).
+import scrollDrivenCss from "../styles/scroll-driven.css?inline";
 
 // port of src/components/SEO.tsx + gatsby-ssr.tsx / gatsby-config.ts head additions
 export interface Props {


### PR DESCRIPTION
## Summary
This PR optimizes the size of injected inline scripts and stylesheets by minifying them during production builds while preserving readable source code during development.

## Key Changes
- **Inline script minification**: Modified the `astro:config:setup` hook to use Vite's `transformWithEsbuild` to minify injected scripts during builds only, reducing ~2.8kB of indentation and comments per page
- **Async injection**: Converted the hook to async to support the asynchronous minification process
- **Stylesheet optimization**: Changed `scroll-driven.css` import from `?raw` to `?inline` to leverage Vite's CSS pipeline for minification in production builds
- **Development experience**: Ensured that `astro dev` continues to work with unminified source code for easier debugging and stepping through code

## Implementation Details
- The minification is conditional on the build command: only applied when `command === "build"`, leaving development builds unminified
- All four injected scripts (theme, clipboard, BMC persist, BMC close button) and the gtag script now go through the same minification pipeline
- The `?inline` query parameter for CSS provides the same string-based behavior as `?raw` but with the added benefit of Vite's CSS processing pipeline

https://claude.ai/code/session_01DJowpch8TcuiNbrb38D1sp