### PR TITLE
Add Playwright end-to-end test suite for blog.miyamo.today

### DIFF
--- a/.claude/skills/e2e-authoring/SKILL.md
+++ b/.claude/skills/e2e-authoring/SKILL.md
@@ -120,6 +120,13 @@ of that file — it exists to leave pictures behind.
   `pressSequentially` only when the point *is* the debounce.
 - **View transitions.** `.header-wrapper` is `transition:persist`; a client-router
   navigation reuses the element. That is what the persistence test checks.
+- **The mobile menu lives inside the header.** `.header-wrapper a[href="/tags"]`
+  matches the desktop nav link *and* the one in the (closed) menu dialog, so a bare
+  click is a strict-mode violation at any width. Filter with
+  `{ visible: true, hasText: label }`.
+- **The code copy button is `display: none` below 1200px** (`views/article-detail.css`).
+  It is in the markup at every width, so `toHaveText` passes on a phone while
+  `click()` hangs until the test times out. Anything that clicks it is `@desktop`.
 - **Absolute urls are production urls.** The build keeps
   `site: "https://blog.miyamo.today"`, so canonical / og:url / share links point
   there even though the page is served from 127.0.0.1.

--- a/.claude/skills/e2e-authoring/SKILL.md
+++ b/.claude/skills/e2e-authoring/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: e2e-authoring
+description: Write or change Playwright end-to-end tests for blog.miyamo.today (files under e2e/). Use when adding a spec for a new screen or feature, updating specs after a UI change, adding a screenshot capture, or extending the mock data the suite builds against. For running an existing suite, use e2e-running instead.
+---
+
+# Authoring e2e tests
+
+## Layout
+
+```
+e2e/
+  package.json          own dependency tree (playwright is NOT a site dependency)
+  playwright.config.ts  projects, webServer, capture-wide defaults
+  fixtures/
+    test.ts             extended `test`, the capture fixture, shared locators
+    algolia.ts          the Algolia stand-in
+  tests/*.spec.ts       one file per screen or feature
+scripts/e2e.mjs         mock API -> astro build -> playwright
+scripts/mock-api.mjs    the blog API / GitHub API / image mock the build reads
+```
+
+Always import from `../fixtures/test`, never from `@playwright/test` directly — the
+extended `test` adds the `capture` and `articleIds` fixtures and blocks third-party
+requests.
+
+```ts
+import { expect, test, visible } from "../fixtures/test";
+```
+
+## What the suite runs against
+
+`bun run e2e` builds the real site with `scripts/mock-api.mjs` standing in for
+blogapi.miyamo.today and the GitHub GraphQL API, then serves `dist/` with
+`astro preview`. Consequences worth knowing before writing an assertion:
+
+- **4 articles, 2 per page.** `ARTICLE_PER_PAGE=2` is set for the build, so the
+  article list is exactly two pages. That is the only reason `Pager.astro`,
+  `/pages/2` and `/tags/{tag}/2` exist to be tested at all.
+- **Tags: `Go` (4 articles) and `AWS` (2).** Prefer reading them off `/tags` over
+  hard-coding — see `tests/tags.spec.ts`.
+- **Article ids are not stable-by-name.** Use the `articleIds` fixture, which reads
+  them from `/feed/rss.xml`.
+- **No recommendations.** The build runs without `OPENAI_API_KEY`, so
+  `Recommend.astro` renders its heading and no cards.
+- **Third-party requests are aborted** (Buy Me a Coffee, giscus, fonts from a CDN).
+  Assert on what the site itself does — e.g. that `#comments` got
+  `data-giscus-mounted="true"` and a `script[src*="giscus.app"]`, not that giscus
+  rendered.
+- **Algolia is intercepted in the browser.** Call `mockAlgolia(page)` from
+  `fixtures/algolia.ts` *before* the `page.goto` that loads the panel. It returns
+  the array of queries the panel actually issued, which is how the debounce test
+  works.
+
+If a test needs data the mock does not serve, extend `scripts/mock-api.mjs` — it is
+the same mock the build verification uses, so keep it representative of the real
+API's shape.
+
+## Viewport projects
+
+Two projects run every file: `desktop-chromium` (1440x900) and `mobile-chromium`
+(Pixel 7). Tag a test title to restrict it:
+
+- `@desktop` — only the desktop project (side TOC, share rail, header nav, and
+  anything that would just run twice for nothing, like the feed/sitemap checks)
+- `@mobile` — only the mobile project (hamburger menu, TOC floating button)
+- no tag — runs in both
+
+The header renders a mobile *and* a desktop copy of the search box and the theme
+toggle. Never select them by index; use the `visible()` helper or the
+`searchTrigger` / `searchDialog` / `themeToggle` helpers from `fixtures/test`.
+
+## Selector conventions
+
+The site ships almost no test-only attributes, so prefer, in order:
+
+1. role + accessible name — `page.getByRole("heading", { level: 1, name: "Tags" })`
+2. the `aria-label`s the components already set — `Go to next page`,
+   `toggle-dark-mode`, `menu-button`, `table-of-contents-button`, `search`,
+   `Share on X`, `Close dialog`
+3. the behavioural hooks the source itself reads — `[data-search-input]`,
+   `[data-search-hits]`, `.index-hit-card`, `.article-card`, `.article-card-link`,
+   `.side-toc`, `.code-copy-button`, `img[data-remote-image]`
+
+Starwind dialogs (`Search`, `Menu`, `TOCModal`) expose their state as
+`data-state="open" | "closed"` on the `<dialog>`; assert on that rather than on
+visibility, which races the open/close animation.
+
+Adding a `data-testid` is a last resort. If you do, put it on the element the
+feature already keys off, not on a wrapper.
+
+## Captures
+
+`capture(name)` writes `e2e/captures/<project>/<name>.png` and attaches it to the
+HTML report. It freezes animations and waits for fonts and images first.
+
+```ts
+test("about page", async ({ page, capture }) => {
+  await page.goto("/about");
+  await expect(page.getByRole("heading", { level: 1, name: "About" })).toBeVisible();
+  await capture("about-light");
+});
+```
+
+Options: `fullPage` (default true), `clip` (a locator, for one component),
+`keepAnimations`. Names must be unique within a test.
+
+New screens belong in the `SCREENS` table in `tests/captures.spec.ts`, which shoots
+every screen in light and dark across both viewports. Keep behaviour assertions out
+of that file — it exists to leave pictures behind.
+
+## Things that bite
+
+- **Japanese hashes.** `history.replaceState(null, "", "#はじめに")` lands in
+  `location.href` percent-encoded. Compare with
+  `expect.poll(() => decodeURIComponent(page.url())).toContain(href)`.
+- **`/pages/1` and `/tags/{tag}/1`** are 301s that a static build emits as
+  meta-refresh pages. Wait with `page.waitForURL((url) => url.pathname === "/")`,
+  not with a response status assertion.
+- **Search debounce is 200ms.** `fill()` fires one input event; use
+  `pressSequentially` only when the point *is* the debounce.
+- **View transitions.** `.header-wrapper` is `transition:persist`; a client-router
+  navigation reuses the element. That is what the persistence test checks.
+- **Absolute urls are production urls.** The build keeps
+  `site: "https://blog.miyamo.today"`, so canonical / og:url / share links point
+  there even though the page is served from 127.0.0.1.
+
+## Before handing the work over
+
+```sh
+bun run e2e:typecheck   # tsc over e2e/
+bun run e2e             # full run (builds first)
+bun run e2e:rerun       # re-run against the dist/ already on disk
+```
+
+A new spec must pass in both projects, or carry an `@desktop` / `@mobile` tag
+explaining why it cannot.

--- a/.claude/skills/e2e-running/SKILL.md
+++ b/.claude/skills/e2e-running/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: e2e-running
+description: Run the Playwright end-to-end suite for blog.miyamo.today and read its results — full runs, a single spec, headed/UI/debug modes, the screenshot captures, the HTML report, and the E2E GitHub Actions workflow. Use when asked to run the e2e tests, capture screenshots of the site, check whether a change broke a screen, or diagnose a failing e2e job. For writing new specs, use e2e-authoring instead.
+---
+
+# Running the e2e suite
+
+## One-time setup
+
+```sh
+bun install          # site dependencies (needs GITHUB_TOKEN, see .npmrc)
+bun run e2e:setup    # e2e/ dependencies + chromium
+```
+
+`e2e:setup` is what CI runs too. `bun run e2e` installs the e2e dependencies on its
+own if they are missing, but it will not download a browser for you.
+
+## The run
+
+```sh
+bun run e2e
+```
+
+That is: start `scripts/mock-api.mjs` → `astro build` against it → `playwright test`,
+which brings up `astro preview` itself. The build is the slow part (a couple of
+minutes); everything after it is seconds.
+
+| command | use |
+| --- | --- |
+| `bun run e2e` | everything, from a fresh build |
+| `bun run e2e:rerun` | re-run against the `dist/` already on disk — the loop to use while iterating on a spec |
+| `bun run e2e:ui` | Playwright's UI mode (time-travel, watch, pick-locator) |
+| `bun run e2e:headed` | watch a real browser window |
+| `bun run e2e:debug` | step through with the inspector |
+| `bun run e2e:report` | open the HTML report of the last run |
+| `bun run e2e:typecheck` | `tsc` over `e2e/` |
+
+Anything after the script name is passed straight to `playwright test`:
+
+```sh
+bun run e2e:rerun tests/search.spec.ts            # one file
+bun run e2e:rerun -g "the pager walks"            # one test by title
+bun run e2e:rerun --project=mobile-chromium       # one viewport
+bun run e2e:rerun --repeat-each=5 -g "@mobile"    # hunt a flake
+```
+
+Env knobs: `E2E_PORT` (preview, default 4321), `E2E_MOCK_PORT` (mock API, default
+8787), `E2E_SKIP_BUILD=1` (same as `--skip-build`), `E2E_CAPTURE_DIR`.
+
+## What a run leaves behind
+
+- `e2e/captures/<project>/<name>.png` — the deliberate screenshots. Every screen in
+  light and dark, at 1440x900 (`desktop-chromium`) and Pixel 7
+  (`mobile-chromium`), plus the search panel, the mobile menu and the TOC modal.
+  Written on pass and on fail.
+- `e2e/playwright-report/` — the HTML report; every capture is attached to the test
+  that took it.
+- `e2e/test-results/` — traces, videos and failure screenshots, kept only for
+  failures.
+
+To hand a screenshot to someone, take it from `e2e/captures/`. To explain a
+failure, open the trace: `cd e2e && ./node_modules/.bin/playwright show-trace
+test-results/<test>/trace.zip`.
+
+## Reading a failure
+
+1. **Everything failed at once, with a blank page.** The build probably did not
+   produce what the suite expects. Look at the `astro build` output above the
+   playwright run; a missing `GITHUB_TOKEN` (GitHub Packages) or an unreachable
+   mock API are the usual causes.
+2. **`no articles found in /feed/rss.xml`.** The build ran without the mock, so the
+   site has no content. Re-run `bun run e2e` rather than `e2e:rerun`.
+3. **One spec, one project.** Check the tag: `@desktop` / `@mobile` tests are meant
+   to run in one project only. A test with no tag that only passes in one is a real
+   bug in the test or in the responsive layout.
+4. **Search specs failing together.** The Algolia stand-in is registered per test
+   with `mockAlgolia(page)`; if a request escaped it, the panel shows
+   "Search failed. Please try again." — the intercept was registered after the
+   navigation.
+5. **A capture test is red.** Captures assert almost nothing; a failure there is a
+   page that never reached its ready state, not a pixel difference (the suite does
+   no visual diffing).
+
+Re-running a single failing test in UI mode is almost always faster than reasoning
+about it:
+
+```sh
+bun run e2e:ui tests/<file>.spec.ts
+```
+
+## CI
+
+`.github/workflows/e2e.yaml` runs on every push to any branch, and on
+`workflow_dispatch`. It needs no deploy secrets — only the default `GITHUB_TOKEN`,
+for the `@miyamo2` package on GitHub Packages.
+
+Two artifacts are uploaded on every run, pass or fail: **e2e-captures** (the
+screenshots) and **e2e-report** (the HTML report plus traces and videos). Download
+`e2e-report`, unzip it, and open `playwright-report/index.html` to get the same
+view as a local run.
+
+If a job fails only in CI, reproduce it with a clean build locally
+(`bun run e2e`), and check the viewport: CI runs both projects, and a local
+`--project=desktop-chromium` habit hides mobile regressions.

--- a/.claude/skills/e2e-running/SKILL.md
+++ b/.claude/skills/e2e-running/SKILL.md
@@ -90,9 +90,10 @@ bun run e2e:ui tests/<file>.spec.ts
 
 ## CI
 
-`.github/workflows/e2e.yaml` runs on every push to any branch, and on
-`workflow_dispatch`. It needs no deploy secrets — only the default `GITHUB_TOKEN`,
-for the `@miyamo2` package on GitHub Packages.
+`.github/workflows/e2e.yaml` runs on every push to a branch other than `main`, and
+on `workflow_dispatch`. (A push to `main` is a merge of a branch the suite already
+ran on; `main`'s own workflow is Publish.) It needs no deploy secrets — only the
+default `GITHUB_TOKEN`, for the `@miyamo2` package on GitHub Packages.
 
 Two artifacts are uploaded on every run, pass or fail: **e2e-captures** (the
 screenshots) and **e2e-report** (the HTML report plus traces and videos). Download

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,67 @@
+name: E2E
+
+# Every branch: the suite builds the site against scripts/mock-api.mjs, so it
+# needs none of the deploy secrets and can run wherever a push lands.
+on:
+  push:
+    branches:
+      - "**"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  e2e:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        env:
+          # @miyamo2/astro-loader-blogapi-miyamo-today is on GitHub Packages (see .npmrc)
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bun install
+
+      - name: Install playwright and chromium
+        run: bun run e2e:setup
+
+      - name: Run e2e tests
+        run: bun run e2e
+
+      # kept whether the run passed or failed: the captures are the point, and a
+      # failure's trace/video is what makes it diagnosable without a local repro
+      - name: Upload captures
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: e2e-captures
+          path: e2e/captures
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Upload playwright report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: e2e-report
+          path: |
+            e2e/playwright-report
+            e2e/test-results
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,11 +1,13 @@
 name: E2E
 
-# Every branch: the suite builds the site against scripts/mock-api.mjs, so it
-# needs none of the deploy secrets and can run wherever a push lands.
+# Work branches only: the suite builds the site against scripts/mock-api.mjs, so
+# it needs none of the deploy secrets and can run wherever a push lands -- but a
+# push to main is a merge of a branch this already ran on, and main's own job is
+# to publish.
 on:
   push:
-    branches:
-      - "**"
+    branches-ignore:
+      - main
   workflow_dispatch:
 
 concurrency:

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,8 @@
+# playwright's own output
+test-results/
+playwright-report/
+blob-report/
+.playwright/
+
+# the capture sweep's screenshots -- artifacts of a run, uploaded by CI
+captures/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,64 @@
+# e2e
+
+Playwright end-to-end tests for blog.miyamo.today.
+
+The suite runs against a **production build** served by `astro preview`, with
+`scripts/mock-api.mjs` standing in for blogapi.miyamo.today and the GitHub GraphQL
+API — so it needs no credentials and produces the same site on every run.
+
+Dependencies live in this directory's own `package.json` (the same arrangement as
+`dev/mock-blogapi`), so Playwright never enters the site's dependency tree.
+
+## Usage
+
+```sh
+bun install        # site dependencies
+bun run e2e:setup  # this directory's dependencies + chromium (once)
+
+bun run e2e        # build + run everything
+bun run e2e:rerun  # re-run against the dist/ already on disk
+bun run e2e:ui     # playwright UI mode
+bun run e2e:report # open the last HTML report
+```
+
+Arguments are forwarded to `playwright test`:
+
+```sh
+bun run e2e:rerun tests/search.spec.ts
+bun run e2e:rerun -g "the pager walks" --project=mobile-chromium
+```
+
+## What it covers
+
+| file | screen / feature |
+| --- | --- |
+| `article-list.spec.ts` | `/` — cards, thumbnails, links, LCP hints |
+| `pagination.spec.ts` | the pager, `/pages/2`, the `/pages/1` redirect |
+| `tags.spec.ts` | `/tags`, `/tags/{tag}`, tag pagination |
+| `article-detail.spec.ts` | `/articles/{id}` — markdown, code copy, images, link cards, comments, share buttons |
+| `toc.spec.ts` | side table of contents and the mobile TOC modal |
+| `about.spec.ts` | `/about` — profile, avatar, social links |
+| `not-found.spec.ts` | the 404 page and its Go Back button |
+| `navigation.spec.ts` | header, footer, mobile menu, view-transition persistence |
+| `theme.spec.ts` | light/dark toggle and its persistence |
+| `search.spec.ts` | the Algolia panel — querying, paging, URL sync, failure states |
+| `feeds.spec.ts` | RSS, sitemap, manifest, robots.txt |
+| `seo.spec.ts` | titles, canonical, Open Graph, JSON-LD |
+| `captures.spec.ts` | the screenshot sweep |
+
+Every file runs in two projects: `desktop-chromium` (1440x900) and
+`mobile-chromium` (Pixel 7). Titles tagged `@desktop` or `@mobile` run in one only.
+
+## Captures
+
+`captures.spec.ts` photographs every screen in light and dark, in both viewports,
+into `captures/<project>/<name>.png`. They are attached to the HTML report and
+uploaded by CI as the `e2e-captures` artifact on every run, pass or fail.
+
+## The build the tests see
+
+`scripts/e2e.mjs` builds with `ARTICLE_PER_PAGE=2` over the mock's 4 articles, so
+the article list is exactly two pages and the pager has something to do. Algolia
+gets fake credentials — every request the panel makes is answered in the browser by
+`fixtures/algolia.ts`. There is no `OPENAI_API_KEY`, so the recommendation block
+renders empty by design.

--- a/e2e/bun.lock
+++ b/e2e/bun.lock
@@ -1,0 +1,31 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "e2e",
+      "dependencies": {
+        "@playwright/test": "1.56.1",
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.2",
+        "typescript": "^5.9.3",
+      },
+    },
+  },
+  "packages": {
+    "@playwright/test": ["@playwright/test@1.56.1", "", { "dependencies": { "playwright": "1.56.1" }, "bin": { "playwright": "cli.js" } }, "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg=="],
+
+    "@types/node": ["@types/node@22.20.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q=="],
+
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "playwright": ["playwright@1.56.1", "", { "dependencies": { "playwright-core": "1.56.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw=="],
+
+    "playwright-core": ["playwright-core@1.56.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+  }
+}

--- a/e2e/fixtures/algolia.ts
+++ b/e2e/fixtures/algolia.ts
@@ -1,0 +1,134 @@
+import type { Page, Route } from "@playwright/test";
+
+/**
+ * Algolia stand-in.
+ *
+ * The build ships fake Algolia credentials (see scripts/e2e.mjs), so the panel
+ * builds a real client and issues real requests -- which are answered here
+ * instead of over the network. That keeps the whole search feature under test
+ * (debounce, paging, highlighting, URL sync, error handling) without an account,
+ * an index, or a flaky third party.
+ *
+ * The client resolves `{appId}-dsn.algolia.net` first and falls back to
+ * `{appId}-{1,2,3}.algolianet.com`, so both host shapes are intercepted.
+ */
+export const ALGOLIA_URL_PATTERNS = [
+  "**://*.algolia.net/**",
+  "**://*.algolianet.com/**",
+  "**://*.algolia.io/**",
+];
+
+export interface MockHit {
+  objectID: string;
+  title: string;
+  content: string;
+  tags: string[];
+  thumbnail: string;
+}
+
+/** enough hits to fill three pages at the panel's 5-per-page */
+export const MOCK_HITS: MockHit[] = Array.from({ length: 12 }, (_, i) => ({
+  objectID: `search-${i + 1}`,
+  title: `検索結果の記事 ${i + 1}`,
+  content: `これは検索結果 ${i + 1} の本文スニペットです。Astro と Playwright の話。`,
+  tags: i % 2 === 0 ? ["Go", "AWS"] : ["Go"],
+  thumbnail: "/logo.png",
+}));
+
+const HITS_PER_PAGE = 5;
+
+interface AlgoliaQuery {
+  query?: string;
+  page?: number;
+  hitsPerPage?: number;
+}
+
+const highlight = (value: string, query: string): string => {
+  if (!query) return value;
+  const index = value.toLowerCase().indexOf(query.toLowerCase());
+  if (index < 0) return value;
+  return (
+    value.slice(0, index) +
+    `<mark>${value.slice(index, index + query.length)}</mark>` +
+    value.slice(index + query.length)
+  );
+};
+
+const page = (hits: MockHit[], query: string, pageIndex: number) => {
+  const nbPages = Math.ceil(hits.length / HITS_PER_PAGE);
+  const slice = hits.slice(pageIndex * HITS_PER_PAGE, (pageIndex + 1) * HITS_PER_PAGE);
+  return {
+    hits: slice.map((hit) => ({
+      ...hit,
+      _highlightResult: {
+        title: { value: highlight(hit.title, query), matchLevel: "full" },
+        tags: hit.tags.map((tag) => ({ value: tag, matchLevel: "none" })),
+      },
+      _snippetResult: {
+        content: { value: highlight(hit.content, query), matchLevel: "full" },
+      },
+    })),
+    nbHits: hits.length,
+    page: pageIndex,
+    nbPages,
+    hitsPerPage: HITS_PER_PAGE,
+    exhaustiveNbHits: true,
+    query,
+    params: "",
+    index: "e2e-index",
+    processingTimeMS: 1,
+  };
+};
+
+/** the query that the panel is told matches nothing */
+export const EMPTY_QUERY = "ヒットしない検索語";
+
+export type AlgoliaMode = "ok" | "error";
+
+interface Options {
+  /** "error" makes every request fail, for the panel's failure branch */
+  mode?: AlgoliaMode;
+  /** hits to serve; defaults to MOCK_HITS */
+  hits?: MockHit[];
+}
+
+/**
+ * Installs the interception. Call before the navigation that loads the panel.
+ * Returns the list of queries the panel actually asked for, so a test can assert
+ * that (for example) debouncing collapsed a burst of keystrokes.
+ */
+export const mockAlgolia = async (target: Page, options: Options = {}): Promise<string[]> => {
+  const { mode = "ok", hits = MOCK_HITS } = options;
+  const queries: string[] = [];
+
+  const handler = async (route: Route) => {
+    const body = route.request().postDataJSON() as { requests?: AlgoliaQuery[] } | null;
+    const requests = body?.requests ?? [{}];
+    const query = requests[0]?.query ?? "";
+    queries.push(query);
+
+    if (mode === "error") {
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ message: "e2e: forced failure" }),
+      });
+      return;
+    }
+
+    const matching = query === EMPTY_QUERY ? [] : hits;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      headers: { "access-control-allow-origin": "*" },
+      body: JSON.stringify({
+        results: requests.map((request) => page(matching, query, request.page ?? 0)),
+      }),
+    });
+  };
+
+  for (const pattern of ALGOLIA_URL_PATTERNS) {
+    await target.route(pattern, handler);
+  }
+  return queries;
+};

--- a/e2e/fixtures/test.ts
+++ b/e2e/fixtures/test.ts
@@ -1,0 +1,189 @@
+import {
+  test as base,
+  expect,
+  type APIRequestContext,
+  type Locator,
+  type Page,
+} from "@playwright/test";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const E2E_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+/**
+ * Where the deliberate screenshots land. These are the run's artifacts -- kept
+ * whether the run passed or failed -- as opposed to playwright's own
+ * only-on-failure screenshots under test-results/.
+ */
+export const CAPTURE_DIR = process.env.E2E_CAPTURE_DIR
+  ? resolve(process.env.E2E_CAPTURE_DIR)
+  : join(E2E_DIR, "captures");
+
+export interface CaptureOptions {
+  /** default true: the whole scrollable page, not just the viewport */
+  fullPage?: boolean;
+  /** limit the shot to one element */
+  clip?: Locator;
+  /** extra hosts to keep animated; by default every animation is frozen */
+  keepAnimations?: boolean;
+}
+
+export type Capture = (name: string, options?: CaptureOptions) => Promise<string>;
+
+/** Hosts a page is allowed to reach. Everything else is aborted (see below). */
+const isAllowedHost = (url: string, baseURL: string | undefined): boolean => {
+  if (url.startsWith("data:") || url.startsWith("blob:")) return true;
+  try {
+    const { hostname } = new URL(url);
+    if (hostname === "127.0.0.1" || hostname === "localhost" || hostname === "[::1]") return true;
+    if (baseURL && hostname === new URL(baseURL).hostname) return true;
+    return false;
+  } catch {
+    return false;
+  }
+};
+
+interface Fixtures {
+  capture: Capture;
+  /** ids of the articles the built site actually contains, newest first */
+  articleIds: string[];
+}
+
+export const test = base.extend<Fixtures>({
+  /**
+   * Third-party requests are aborted for every test.
+   *
+   * The pages load the Buy Me a Coffee widget, giscus and remote fonts. None of
+   * them is this site's behaviour, all of them are unreachable from a locked-down
+   * CI runner, and letting them through makes captures depend on whatever a CDN
+   * served that minute. Registered here first, so a test's own `page.route` (the
+   * Algolia stand-in) still takes precedence.
+   */
+  page: async ({ page, baseURL }, use) => {
+    await page.route("**/*", async (route) => {
+      if (isAllowedHost(route.request().url(), baseURL)) {
+        await route.fallback();
+        return;
+      }
+      await route.abort();
+    });
+    await use(page);
+  },
+
+  capture: async ({ page }, use, testInfo) => {
+    const taken = new Set<string>();
+
+    const capture: Capture = async (name, options = {}) => {
+      const { fullPage = true, clip, keepAnimations = false } = options;
+      if (taken.has(name)) {
+        throw new Error(`capture("${name}") was already taken in this test`);
+      }
+      taken.add(name);
+
+      if (!keepAnimations) {
+        // scroll-driven animations, the card hover transform and the caret all
+        // move between two otherwise identical runs
+        await page.addStyleTag({
+          content: `*, *::before, *::after {
+            animation-duration: 0s !important;
+            animation-delay: 0s !important;
+            transition-duration: 0s !important;
+            transition-delay: 0s !important;
+            caret-color: transparent !important;
+          }`,
+        });
+      }
+      await settle(page);
+
+      const file = join(CAPTURE_DIR, testInfo.project.name, `${name}.png`);
+      await mkdir(dirname(file), { recursive: true });
+      const buffer = await (clip ?? page).screenshot(
+        clip ? { animations: "disabled" } : { fullPage, animations: "disabled" }
+      );
+      await writeFile(file, buffer);
+      // also lands in the HTML report, next to the test that took it
+      await testInfo.attach(name, { body: buffer, contentType: "image/png" });
+      return file;
+    };
+
+    await use(capture);
+  },
+
+  articleIds: async ({ playwright, baseURL }, use) => {
+    await use(await loadArticleIds(playwright, baseURL));
+  },
+});
+
+/**
+ * The feed is the cheapest list of every article the build produced, and it is
+ * in the same order as the article list page. Fetched once per worker process:
+ * `baseURL` is a test-scoped option, so this cannot be a worker fixture, but the
+ * result is the same for every test in the run.
+ */
+let articleIdsCache: Promise<string[]> | undefined;
+
+const loadArticleIds = (
+  playwright: { request: { newContext: (options: { baseURL?: string }) => Promise<APIRequestContext> } },
+  baseURL: string | undefined
+): Promise<string[]> =>
+  (articleIdsCache ??= (async () => {
+    const request = await playwright.request.newContext({ baseURL });
+    try {
+      const response = await request.get("/feed/rss.xml");
+      const xml = await response.text();
+      const ids = [...xml.matchAll(/<link>[^<]*\/articles\/([^<]+)<\/link>/g)].map(
+        (match) => match[1]
+      );
+      if (ids.length === 0) {
+        throw new Error("no articles found in /feed/rss.xml; did the build run against the mock?");
+      }
+      return ids;
+    } finally {
+      await request.dispose();
+    }
+  })());
+
+/**
+ * Waits for the things a screenshot depends on: the load event, webfonts, and
+ * every <img> that is going to resolve.
+ */
+export const settle = async (page: Page): Promise<void> => {
+  await page.waitForLoadState("load");
+  await page.evaluate(() => document.fonts?.ready);
+  await page.evaluate(async () => {
+    await Promise.all(
+      [...document.images]
+        .filter((image) => !image.complete)
+        .map(
+          (image) =>
+            new Promise<void>((resolve) => {
+              image.addEventListener("load", () => resolve(), { once: true });
+              image.addEventListener("error", () => resolve(), { once: true });
+            })
+        )
+    );
+  });
+};
+
+/**
+ * The header renders a mobile and a desktop copy of the search box and the theme
+ * toggle; only one of the two is on screen at any width. Every helper below picks
+ * the visible one.
+ */
+export const visible = (locator: Locator): Locator => locator.filter({ visible: true });
+
+export const searchTrigger = (page: Page): Locator =>
+  visible(page.locator('button[aria-label="search"]'));
+
+export const searchDialog = (page: Page): Locator =>
+  visible(page.locator('.algolia-search dialog[data-slot="dialog-content"]'));
+
+export const themeToggle = (page: Page): Locator =>
+  visible(page.locator('button[aria-label="toggle-dark-mode"]'));
+
+export const currentTheme = (page: Page): Promise<"dark" | "light"> =>
+  page.evaluate(() => (document.documentElement.classList.contains("dark") ? "dark" : "light"));
+
+export { expect };
+export type { APIRequestContext, Locator, Page } from "@playwright/test";

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "e2e",
+  "private": true,
+  "description": "playwright end-to-end suite; kept out of the site's dependency tree (like dev/mock-blogapi)",
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@playwright/test": "1.56.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "typescript": "^5.9.3"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,70 @@
+import { defineConfig, devices } from "@playwright/test";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const E2E_DIR = dirname(fileURLToPath(import.meta.url));
+// scripts/e2e.mjs passes this; the fallback keeps a bare `playwright test` working
+const SITE_ROOT = process.env.E2E_ROOT ?? resolve(E2E_DIR, "..");
+
+const PORT = process.env.E2E_PORT ?? "4321";
+const BASE_URL = process.env.E2E_BASE_URL ?? `http://127.0.0.1:${PORT}`;
+
+export default defineConfig({
+  testDir: "./tests",
+  // traces, videos and failure screenshots; the deliberate captures go to captures/
+  outputDir: "./test-results",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  reporter: [
+    ["list"],
+    ["html", { outputFolder: "playwright-report", open: "never" }],
+    ["json", { outputFile: "test-results/results.json" }],
+  ],
+  use: {
+    baseURL: BASE_URL,
+    trace: "retain-on-failure",
+    video: "retain-on-failure",
+    screenshot: "only-on-failure",
+    // the site is Japanese and formats dates in JST; pin both so a rendered
+    // date is the same string on a developer's machine and on a CI runner
+    locale: "ja-JP",
+    timezoneId: "Asia/Tokyo",
+    // the theme script falls back to prefers-color-scheme when localStorage is
+    // empty, so every test starts in light mode unless it says otherwise
+    colorScheme: "light",
+  },
+  projects: [
+    {
+      name: "desktop-chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        // >= lg: the desktop header, the side TOC and the share rail are all
+        // rendered above this width
+        viewport: { width: 1440, height: 900 },
+      },
+      // the mobile-only surfaces (hamburger menu, TOC fab) are not rendered here
+      grepInvert: /@mobile/,
+    },
+    {
+      name: "mobile-chromium",
+      use: {
+        ...devices["Pixel 7"],
+      },
+      // layout-specific desktop assertions do not hold on a 412px viewport
+      grepInvert: /@desktop/,
+    },
+  ],
+  webServer: {
+    // the suite runs against the built site, never against `astro dev`
+    command: `bunx astro preview --host 127.0.0.1 --port ${PORT}`,
+    cwd: SITE_ROOT,
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    stdout: "ignore",
+    stderr: "pipe",
+  },
+});

--- a/e2e/tests/about.spec.ts
+++ b/e2e/tests/about.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "../fixtures/test";
+
+test.describe("about page (/about)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/about");
+  });
+
+  test("shows the GitHub profile the build fetched", async ({ page }) => {
+    await expect(page.getByRole("heading", { level: 1, name: "About" })).toBeVisible();
+
+    const login = page.getByRole("heading", { level: 2 });
+    await expect(login).toBeVisible();
+    expect((await login.innerText()).trim()).not.toEqual("");
+
+    // the bio comes straight from the GitHub GraphQL response
+    await expect(page.locator("main p").first()).not.toBeEmpty();
+  });
+
+  test("renders the avatar", async ({ page }) => {
+    const avatar = page.locator('img[alt="GitHubAvatar:miyamo2"]');
+    await expect(avatar).toBeVisible();
+    await expect(avatar).toHaveAttribute("loading", "eager");
+    expect(await avatar.evaluate((img: HTMLImageElement) => img.naturalWidth)).toBeGreaterThan(0);
+  });
+
+  test("links to GitHub and to every social account with an icon", async ({ page }) => {
+    const github = page.locator('main a[aria-label="GitHub"]');
+    await expect(github).toBeVisible();
+    await expect(github).toHaveAttribute("href", /^https:\/\/github\.com\//);
+    await expect(github).toHaveAttribute("target", "_blank");
+    await expect(github).toHaveAttribute("rel", "noopener noreferrer");
+
+    const socials = page.locator('main a[aria-label^="social account link:"]');
+    expect(await socials.count()).toBeGreaterThan(0);
+    for (const social of await socials.all()) {
+      await expect(social).toHaveAttribute("href", /^https?:\/\//);
+      await expect(social).toHaveAttribute("target", "_blank");
+    }
+  });
+});

--- a/e2e/tests/article-detail.spec.ts
+++ b/e2e/tests/article-detail.spec.ts
@@ -1,0 +1,130 @@
+import { expect, test, visible } from "../fixtures/test";
+
+test.describe("article detail page (/articles/[id])", () => {
+  test.beforeEach(async ({ page, articleIds }) => {
+    await page.goto(`/articles/${articleIds[0]}`);
+  });
+
+  test("shows the title, tags, publication date and hero image", async ({ page, articleIds }) => {
+    const id = articleIds[0];
+
+    const heading = page.getByRole("heading", { level: 1 });
+    await expect(heading).toBeVisible();
+    expect((await heading.innerText()).trim()).not.toEqual("");
+
+    const tagLinks = page.locator('main a[href^="/tags/"]');
+    expect(await tagLinks.count()).toBeGreaterThan(0);
+    await expect(tagLinks.first()).toContainText("#");
+
+    await expect(page.locator("main")).toContainText(/\d{4}\/\d{2}\/\d{2}/);
+
+    const hero = page.locator(`img[alt="ArticleImage:${id}"]`).first();
+    await expect(hero).toBeVisible();
+    await expect(hero).toHaveAttribute("loading", "eager");
+    expect(await hero.evaluate((img: HTMLImageElement) => img.naturalWidth)).toBeGreaterThan(0);
+  });
+
+  test("renders the whole markdown body", async ({ page }) => {
+    const body = page.locator("article .markdown-body");
+    await expect(body).toBeVisible();
+
+    // headings (satteri's heading-ids gives every one an anchor target)
+    const headings = body.locator("h2[id], h3[id]");
+    expect(await headings.count()).toBeGreaterThan(0);
+
+    // fenced code, with the copy affordance the plugin injects
+    await expect(body.locator("pre").first()).toBeVisible();
+    await expect(body.locator(".code-copy-button").first()).toHaveText("Copy");
+
+    // table, raw html block and footnote all survive the pipeline
+    await expect(body.locator("table")).toBeVisible();
+    await expect(body.locator(".raw-html-test strong")).toHaveText("生HTMLブロック");
+    await expect(body).toContainText("これは脚注です。");
+  });
+
+  test("body images are optimized and load", async ({ page }) => {
+    const image = page.locator("article .markdown-body img").first();
+    await expect(image).toBeVisible();
+    expect(await image.evaluate((img: HTMLImageElement) => img.naturalWidth)).toBeGreaterThan(0);
+  });
+
+  test("a bare url becomes a link card", async ({ page }) => {
+    // the mock serves /ogp-page with og: tags for satteri-link-card to read
+    const card = page.locator('article .markdown-body a[href*="/ogp-page"]');
+    await expect(card.first()).toBeVisible();
+    await expect(card.first()).toContainText(/Mock OGP Page|ogp-page/);
+  });
+
+  test("the copy button copies the code block", async ({ page, context }) => {
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+    const body = page.locator("article .markdown-body");
+    const button = body.locator(".code-copy-button").first();
+    const code = (await body.locator("pre").first().innerText()).trim();
+
+    await button.click();
+    await expect(button).toHaveText("Copied!");
+    await expect(button).toHaveClass(/copied/);
+
+    const clipboard = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipboard.trim()).toContain(code.split("\n")[0]);
+
+    // the handler restores the label after 1.5s
+    await expect(button).toHaveText("Copy", { timeout: 5_000 });
+  });
+
+  test("a tag on the article opens that tag's list", async ({ page }) => {
+    const tagLink = page.locator('main a[href^="/tags/"]').first();
+    const label = (await tagLink.innerText()).trim();
+    await tagLink.click();
+    await expect(page).toHaveURL(/\/tags\/[^/]+$/);
+    await expect(page.getByRole("heading", { level: 1 })).toHaveText(label);
+  });
+
+  test("the recommend block is rendered", async ({ page }) => {
+    // the recommendations themselves need OpenAI + qdrant, which the e2e build
+    // deliberately runs without; the block itself must still be there
+    await expect(
+      visible(page.getByRole("heading", { level: 2, name: "Recommend Articles" }))
+    ).toBeVisible();
+  });
+
+  test("the giscus comment container mounts its loader", async ({ page }) => {
+    const comments = page.locator("#comments");
+    await expect(comments).toHaveAttribute("data-giscus-mounted", "true");
+    // the request itself is blocked in e2e; the script element is what this owns
+    await expect(comments.locator('script[src*="giscus.app"]')).toHaveCount(1);
+  });
+});
+
+test.describe("share buttons", () => {
+  test.beforeEach(async ({ page, articleIds }) => {
+    await page.goto(`/articles/${articleIds[0]}`);
+  });
+
+  for (const network of ["Facebook", "X", "LinkedIn", "Reddit", "Hatena Bookmark", "LINE"]) {
+    test(`links to ${network} with the article url`, async ({ page, articleIds }) => {
+      const link = visible(page.locator(`main a[aria-label="Share on ${network}"]`)).first();
+      await expect(link).toBeVisible();
+      const href = (await link.getAttribute("href")) ?? "";
+      expect(decodeURIComponent(href)).toContain(
+        `https://blog.miyamo.today/articles/${articleIds[0]}`
+      );
+      await expect(link).toHaveAttribute("target", "_blank");
+      await expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    });
+  }
+
+  test("the vertical rail also offers email @desktop", async ({ page, articleIds }) => {
+    const link = visible(page.locator('main a[aria-label="Share by Email"]')).first();
+    await expect(link).toBeVisible();
+    const href = (await link.getAttribute("href")) ?? "";
+    expect(href.startsWith("mailto:")).toBe(true);
+    expect(decodeURIComponent(href)).toContain(`/articles/${articleIds[0]}`);
+    // a mail client is not a new tab
+    await expect(link).not.toHaveAttribute("target", "_blank");
+  });
+
+  test("the horizontal stack omits email @mobile", async ({ page }) => {
+    await expect(visible(page.locator('main a[aria-label="Share by Email"]'))).toHaveCount(0);
+  });
+});

--- a/e2e/tests/article-detail.spec.ts
+++ b/e2e/tests/article-detail.spec.ts
@@ -55,7 +55,9 @@ test.describe("article detail page (/articles/[id])", () => {
     await expect(card.first()).toContainText(/Mock OGP Page|ogp-page/);
   });
 
-  test("the copy button copies the code block", async ({ page, context }) => {
+  // the button is `display: none` below 1200px (views/article-detail.css), so
+  // the click only exists to be made at desktop widths
+  test("the copy button copies the code block @desktop", async ({ page, context }) => {
     await context.grantPermissions(["clipboard-read", "clipboard-write"]);
     const body = page.locator("article .markdown-body");
     const button = body.locator(".code-copy-button").first();
@@ -70,6 +72,14 @@ test.describe("article detail page (/articles/[id])", () => {
 
     // the handler restores the label after 1.5s
     await expect(button).toHaveText("Copy", { timeout: 5_000 });
+  });
+
+  test("the copy button stays out of the way on a phone @mobile", async ({ page }) => {
+    // it overlaps the code on a narrow screen, so it is hidden below 1200px --
+    // the markup is still there, only the button is not shown
+    const button = page.locator("article .markdown-body .code-copy-button").first();
+    await expect(button).toHaveText("Copy");
+    await expect(button).toBeHidden();
   });
 
   test("a tag on the article opens that tag's list", async ({ page }) => {

--- a/e2e/tests/article-list.spec.ts
+++ b/e2e/tests/article-list.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "../fixtures/test";
+
+// scripts/e2e.mjs builds with ARTICLE_PER_PAGE=2 over the mock's 4 articles
+const PER_PAGE = 2;
+
+test.describe("article list page (/)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("renders one page worth of article cards", async ({ page }) => {
+    await expect(page.getByRole("heading", { level: 1, name: "Articles" })).toBeVisible();
+    await expect(page.locator(".article-card")).toHaveCount(PER_PAGE);
+  });
+
+  test("each card carries a title link, tags, an excerpt and a date", async ({ page }) => {
+    const card = page.locator(".article-card").first();
+
+    const titleLink = card.locator("a.article-card-link");
+    const title = (await titleLink.innerText()).trim();
+    expect(title).not.toEqual("");
+    await expect(titleLink).toHaveAttribute("href", /^\/articles\/.+/);
+    await expect(titleLink).toHaveAttribute("aria-label", `link: ${title}`);
+
+    const tagLinks = card.locator(".article-card-tags a");
+    expect(await tagLinks.count()).toBeGreaterThan(0);
+    await expect(tagLinks.first()).toHaveAttribute("href", /^\/tags\/.+/);
+
+    // format(createdAt, "YYYY/MM/DD")
+    await expect(card).toContainText(/\d{4}\/\d{2}\/\d{2}/);
+    await expect(card.locator("p.text-muted-foreground")).not.toBeEmpty();
+  });
+
+  test("the first thumbnail is eager (it is the LCP candidate) and the rest are lazy", async ({
+    page,
+  }) => {
+    const thumbnails = page.locator(".article-card-thumbnail img[data-remote-image]");
+    await expect(thumbnails.first()).toHaveAttribute("loading", "eager");
+    await expect(thumbnails.first()).toHaveAttribute("fetchpriority", "high");
+    await expect(thumbnails.nth(1)).toHaveAttribute("loading", "lazy");
+  });
+
+  test("thumbnails actually decode", async ({ page }) => {
+    const thumbnail = page.locator(".article-card-thumbnail img[data-remote-image]").first();
+    await expect(thumbnail).toBeVisible();
+    const width = await thumbnail.evaluate((img: HTMLImageElement) => img.naturalWidth);
+    expect(width).toBeGreaterThan(0);
+  });
+
+  test("the title link opens the article", async ({ page }) => {
+    const titleLink = page.locator("a.article-card-link").first();
+    const href = await titleLink.getAttribute("href");
+    await titleLink.click();
+    await expect(page).toHaveURL(new RegExp(`${href}$`));
+    await expect(page.locator("main article .markdown-body")).toBeVisible();
+  });
+
+  test("a card's tag link opens that tag's list", async ({ page }) => {
+    const tagLink = page.locator(".article-card-tags a").first();
+    const label = (await tagLink.innerText()).trim();
+    await tagLink.click();
+    await expect(page).toHaveURL(/\/tags\/[^/]+$/);
+    await expect(page.getByRole("heading", { level: 1 })).toHaveText(label);
+  });
+});

--- a/e2e/tests/captures.spec.ts
+++ b/e2e/tests/captures.spec.ts
@@ -1,0 +1,116 @@
+import { mockAlgolia } from "../fixtures/algolia";
+import { expect, searchDialog, searchTrigger, test, themeToggle, type Page } from "../fixtures/test";
+
+/**
+ * The capture sweep.
+ *
+ * Every other spec asserts behaviour; this one exists to leave a picture of each
+ * screen behind. The files land in e2e/captures/<project>/<name>.png and are
+ * attached to the HTML report, so a CI run ships a full visual record of the
+ * build without anyone having to reproduce it locally.
+ *
+ * Both viewports are covered because both projects run this file.
+ */
+
+const inDark = async (page: Page): Promise<void> => {
+  await themeToggle(page).click();
+  await expect(page.locator("html")).toHaveClass(/dark/);
+};
+
+interface Screen {
+  name: string;
+  /** brings the page to the state worth photographing */
+  open: (page: Page, articleIds: string[]) => Promise<unknown>;
+  ready: (page: Page) => Promise<unknown>;
+}
+
+const SCREENS: Screen[] = [
+  {
+    name: "article-list",
+    open: (page) => page.goto("/"),
+    ready: (page) => expect(page.locator(".article-card").first()).toBeVisible(),
+  },
+  {
+    name: "article-list-page-2",
+    open: (page) => page.goto("/pages/2"),
+    ready: (page) => expect(page.locator(".article-card").first()).toBeVisible(),
+  },
+  {
+    name: "tags",
+    open: (page) => page.goto("/tags"),
+    ready: (page) => expect(page.getByRole("heading", { level: 1, name: "Tags" })).toBeVisible(),
+  },
+  {
+    name: "tagged-articles",
+    // reached through the tag list, so the tag's id never has to be restated here
+    open: async (page) => {
+      await page.goto("/tags");
+      await page.locator('main a[href^="/tags/"]').first().click();
+      await page.waitForURL((url) => /^\/tags\/[^/]+$/.test(url.pathname));
+    },
+    ready: (page) => expect(page.locator(".article-card").first()).toBeVisible(),
+  },
+  {
+    name: "article-detail",
+    open: (page, articleIds) => page.goto(`/articles/${articleIds[0]}`),
+    ready: (page) => expect(page.locator("article .markdown-body")).toBeVisible(),
+  },
+  {
+    name: "about",
+    open: (page) => page.goto("/about"),
+    ready: (page) => expect(page.getByRole("heading", { level: 1, name: "About" })).toBeVisible(),
+  },
+  {
+    name: "not-found",
+    open: (page) => page.goto("/this-path-does-not-exist"),
+    ready: (page) =>
+      expect(page.getByRole("heading", { level: 1, name: "Page Not Found" })).toBeVisible(),
+  },
+];
+
+test.describe("captures", () => {
+  for (const screen of SCREENS) {
+    test(`${screen.name} in both themes`, async ({ page, articleIds, capture }) => {
+      await screen.open(page, articleIds);
+      await screen.ready(page);
+      await capture(`${screen.name}-light`);
+
+      await inDark(page);
+      await screen.ready(page);
+      await capture(`${screen.name}-dark`);
+    });
+  }
+
+  test("search panel with results", async ({ page, capture }) => {
+    await mockAlgolia(page);
+    await page.goto("/");
+
+    await searchTrigger(page).click();
+    const dialog = searchDialog(page);
+    await expect(dialog).toHaveAttribute("data-state", "open");
+    await dialog.locator("[data-search-input]").fill("検索結果");
+    await expect(dialog.locator(".index-hit-card").first()).toBeVisible();
+
+    await capture("search-results-light");
+  });
+
+  test("mobile menu @mobile", async ({ page, capture }) => {
+    await page.goto("/");
+    await page.locator('button[aria-label="menu-button"]').click();
+    await expect(page.locator("#menu-modal dialog")).toHaveAttribute("data-state", "open");
+    await capture("menu-modal", { fullPage: false });
+  });
+
+  test("table of contents modal @mobile", async ({ page, articleIds, capture }) => {
+    await page.goto(`/articles/${articleIds[0]}`);
+    await page.locator('button[aria-label="table-of-contents-button"]').click();
+    await expect(page.locator("#toc-modal dialog")).toHaveAttribute("data-state", "open");
+    await capture("toc-modal", { fullPage: false });
+  });
+
+  test("article sidebar @desktop", async ({ page, articleIds, capture }) => {
+    await page.goto(`/articles/${articleIds[0]}`);
+    await expect(page.locator(".side-toc")).toBeVisible();
+    await capture("article-sidebar", { clip: page.locator(".article-sidebar").first() });
+  });
+});

--- a/e2e/tests/feeds.spec.ts
+++ b/e2e/tests/feeds.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "../fixtures/test";
+
+// static assets and generated documents; no browser needed, so these run once
+test.describe.configure({ mode: "parallel" });
+
+test.describe("generated documents @desktop", () => {
+  test("the RSS feed lists every article", async ({ request, articleIds }) => {
+    const response = await request.get("/feed/rss.xml");
+    expect(response.status()).toBe(200);
+    expect(response.headers()["content-type"]).toContain("xml");
+
+    const xml = await response.text();
+    expect(xml).toContain("<rss");
+    expect(xml).toContain("blog.miyamo.today :: RSS feed");
+    expect(xml).toContain("<language>ja</language>");
+    for (const id of articleIds) {
+      expect(xml).toContain(`https://blog.miyamo.today/articles/${id}`);
+    }
+  });
+
+  test("the sitemap indexes the site and skips the redirecting page 1s", async ({ request }) => {
+    const index = await request.get("/sitemap-index.xml");
+    expect(index.status()).toBe(200);
+
+    const indexXml = await index.text();
+    const [firstSitemap] = [...indexXml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((match) => match[1]);
+    expect(firstSitemap).toBeTruthy();
+
+    const sitemap = await request.get(new URL(firstSitemap).pathname);
+    expect(sitemap.status()).toBe(200);
+    const sitemapXml = await sitemap.text();
+
+    expect(sitemapXml).toContain("https://blog.miyamo.today/");
+    // /pages/1 and /tags/{tag}/1 are 301s; listing them earns nothing but
+    // "page with redirect" reports
+    expect(sitemapXml).not.toMatch(/<loc>[^<]*\/pages\/1\/?<\/loc>/);
+    expect(sitemapXml).not.toMatch(/<loc>[^<]*\/tags\/[^/<]+\/1\/?<\/loc>/);
+    // articles carry a lastmod so a crawler can tell an edit happened
+    expect(sitemapXml).toContain("<lastmod>");
+  });
+
+  test("the web manifest is served", async ({ request }) => {
+    const response = await request.get("/manifest.webmanifest");
+    expect(response.status()).toBe(200);
+    const manifest = JSON.parse(await response.text());
+    expect(manifest.name ?? manifest.short_name).toBeTruthy();
+    expect(Array.isArray(manifest.icons)).toBe(true);
+  });
+
+  test("robots.txt is served", async ({ request }) => {
+    const response = await request.get("/robots.txt");
+    expect(response.status()).toBe(200);
+    expect(await response.text()).toContain("User-agent");
+  });
+});

--- a/e2e/tests/navigation.spec.ts
+++ b/e2e/tests/navigation.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "../fixtures/test";
+
+test.describe("header", () => {
+  test("the logo links home", async ({ page }) => {
+    await page.goto("/about");
+    const logo = page.locator('.header-wrapper a[href="/"]').first();
+    await expect(logo.locator('img[alt="logo"]')).toBeVisible();
+
+    await logo.click();
+    await page.waitForURL((url) => url.pathname === "/");
+    await expect(page.getByRole("heading", { level: 1, name: "Articles" })).toBeVisible();
+  });
+
+  for (const [label, path, heading] of [
+    ["Home", "/", "Articles"],
+    ["Tags", "/tags", "Tags"],
+    ["About", "/about", "About"],
+  ] as const) {
+    test(`the ${label} link opens ${path} @desktop`, async ({ page }) => {
+      await page.goto("/about");
+      await page.locator(`.header-wrapper a[href="${path}"]`).filter({ hasText: label }).click();
+      await page.waitForURL((url) => url.pathname === path);
+      await expect(page.getByRole("heading", { level: 1, name: heading })).toBeVisible();
+    });
+  }
+
+  test("the RSS link points at the feed @desktop", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator('.header-wrapper a[href="/feed/rss.xml"]')).toContainText("RSS");
+  });
+
+  test("the header survives a client-router navigation", async ({ page }) => {
+    await page.goto("/");
+    // transition:persist means the very same element is reused across the swap
+    await page.evaluate(() => {
+      const header = document.querySelector(".header-wrapper") as HTMLElement & {
+        __e2e?: string;
+      };
+      header.__e2e = "persisted";
+    });
+
+    await page.locator("a.article-card-link").first().click();
+    await expect(page.locator("article .markdown-body")).toBeVisible();
+
+    const persisted = await page.evaluate(
+      () => (document.querySelector(".header-wrapper") as HTMLElement & { __e2e?: string }).__e2e
+    );
+    expect(persisted).toBe("persisted");
+  });
+
+  test("the footer is on every page", async ({ page }) => {
+    for (const path of ["/", "/tags", "/about"]) {
+      await page.goto(path);
+      await expect(page.locator("#footer")).toContainText("Copyright © miyamo2");
+    }
+  });
+});
+
+test.describe("mobile menu @mobile", () => {
+  test("opens, lists the destinations and closes again", async ({ page }) => {
+    await page.goto("/");
+
+    const trigger = page.locator('button[aria-label="menu-button"]');
+    await expect(trigger).toBeVisible();
+    await trigger.click();
+
+    const dialog = page.locator("#menu-modal dialog");
+    await expect(dialog).toHaveAttribute("data-state", "open");
+    await expect(page.getByRole("heading", { name: "Menu" })).toBeVisible();
+    for (const [label, path] of [
+      ["Home", "/"],
+      ["Tags", "/tags"],
+      ["About", "/about"],
+    ] as const) {
+      await expect(dialog.locator(`a[href="${path}"]`)).toContainText(label);
+    }
+
+    await dialog.locator("button[data-dialog-close]").click();
+    await expect(dialog).toHaveAttribute("data-state", "closed");
+  });
+
+  test("picking a destination navigates and closes the menu", async ({ page }) => {
+    await page.goto("/");
+    await page.locator('button[aria-label="menu-button"]').click();
+
+    const dialog = page.locator("#menu-modal dialog");
+    await expect(dialog).toHaveAttribute("data-state", "open");
+    await dialog.locator('a[href="/tags"]').click();
+
+    await page.waitForURL((url) => url.pathname === "/tags");
+    await expect(page.getByRole("heading", { level: 1, name: "Tags" })).toBeVisible();
+    await expect(page.locator("#menu-modal dialog")).toHaveAttribute("data-state", "closed");
+  });
+
+  test("the desktop nav is not rendered on a phone", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator('.header-wrapper a[href="/feed/rss.xml"]')).toBeHidden();
+  });
+});

--- a/e2e/tests/navigation.spec.ts
+++ b/e2e/tests/navigation.spec.ts
@@ -18,7 +18,12 @@ test.describe("header", () => {
   ] as const) {
     test(`the ${label} link opens ${path} @desktop`, async ({ page }) => {
       await page.goto("/about");
-      await page.locator(`.header-wrapper a[href="${path}"]`).filter({ hasText: label }).click();
+      // Menu.astro renders inside the header too, so its (closed, invisible)
+      // dialog holds a second link to each destination
+      await page
+        .locator(`.header-wrapper a[href="${path}"]`)
+        .filter({ visible: true, hasText: label })
+        .click();
       await page.waitForURL((url) => url.pathname === path);
       await expect(page.getByRole("heading", { level: 1, name: heading })).toBeVisible();
     });

--- a/e2e/tests/not-found.spec.ts
+++ b/e2e/tests/not-found.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "../fixtures/test";
+
+test.describe("404 page", () => {
+  test("an unknown path serves the not-found page", async ({ page }) => {
+    const response = await page.goto("/this-path-does-not-exist");
+    expect(response?.status()).toBe(404);
+
+    await expect(page.getByRole("heading", { level: 1, name: "Page Not Found" })).toBeVisible();
+    await expect(page.getByText("Oops! This page has been removed or relocated.")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Go Back" })).toBeVisible();
+  });
+
+  test("Go Back returns to the previous page", async ({ page }) => {
+    await page.goto("/about");
+    await page.goto("/this-path-does-not-exist");
+
+    await page.getByRole("button", { name: "Go Back" }).click();
+    await page.waitForURL((url) => url.pathname === "/about");
+    await expect(page.getByRole("heading", { level: 1, name: "About" })).toBeVisible();
+  });
+
+  test("the header is still usable from the 404 page", async ({ page }) => {
+    await page.goto("/this-path-does-not-exist");
+    await page.locator('header, .header-wrapper').first().waitFor();
+    await page.locator('a[href="/"]').first().click();
+    await page.waitForURL((url) => url.pathname === "/");
+    await expect(page.getByRole("heading", { level: 1, name: "Articles" })).toBeVisible();
+  });
+});

--- a/e2e/tests/pagination.spec.ts
+++ b/e2e/tests/pagination.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "../fixtures/test";
+
+/**
+ * The mock serves 4 articles and the e2e build sets ARTICLE_PER_PAGE=2, so the
+ * article list is exactly two pages: enough for every branch of Pager.astro
+ * (first/prev/next/last, the active page, the disabled edges) without the
+ * ellipsis, which only appears past 7 pages.
+ */
+const LAST_PAGE = 2;
+
+test.describe("pagination", () => {
+  test("page 1 disables the backward controls and enables the forward ones", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page.getByLabel("Go to first page")).toHaveAttribute("aria-disabled", "true");
+    await expect(page.getByLabel("Go to previous page")).toHaveAttribute("aria-disabled", "true");
+    await expect(page.getByLabel("Go to page 1")).toHaveAttribute("aria-current", "page");
+    await expect(page.getByLabel("Go to next page")).toHaveAttribute("href", `/pages/2`);
+    await expect(page.getByLabel("Go to last page")).toHaveAttribute("href", `/pages/${LAST_PAGE}`);
+  });
+
+  test("the next link walks to /pages/2, which shows different articles", async ({ page }) => {
+    await page.goto("/");
+    const firstPageTitles = await page.locator("a.article-card-link").allInnerTexts();
+
+    await page.getByLabel("Go to next page").click();
+    await expect(page).toHaveURL(/\/pages\/2$/);
+
+    const secondPageTitles = await page.locator("a.article-card-link").allInnerTexts();
+    expect(secondPageTitles).not.toEqual(firstPageTitles);
+    expect(secondPageTitles.length).toBeGreaterThan(0);
+  });
+
+  test("the last page disables the forward controls", async ({ page }) => {
+    await page.goto(`/pages/${LAST_PAGE}`);
+
+    await expect(page.getByLabel(`Go to page ${LAST_PAGE}`)).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+    await expect(page.getByLabel("Go to next page")).toHaveAttribute("aria-disabled", "true");
+    await expect(page.getByLabel("Go to last page")).toHaveAttribute("aria-disabled", "true");
+    await expect(page.getByLabel("Go to first page")).toHaveAttribute("href", "/");
+  });
+
+  test("a numbered link goes straight to that page", async ({ page }) => {
+    await page.goto("/");
+    await page.getByLabel(`Go to page ${LAST_PAGE}`).click();
+    await expect(page).toHaveURL(new RegExp(`/pages/${LAST_PAGE}$`));
+  });
+
+  test("/pages/1 redirects to /", async ({ page }) => {
+    await page.goto("/pages/1");
+    // static output: Astro emits a meta-refresh page for the 301
+    await page.waitForURL((url) => url.pathname === "/");
+    await expect(page.getByRole("heading", { level: 1, name: "Articles" })).toBeVisible();
+  });
+});

--- a/e2e/tests/search.spec.ts
+++ b/e2e/tests/search.spec.ts
@@ -1,0 +1,179 @@
+import { EMPTY_QUERY, MOCK_HITS, mockAlgolia } from "../fixtures/algolia";
+import { expect, searchDialog, searchTrigger, test, type Page } from "../fixtures/test";
+
+const QUERY = "Astro";
+
+const openPanel = async (page: Page) => {
+  await searchTrigger(page).click();
+  const dialog = searchDialog(page);
+  await expect(dialog).toHaveAttribute("data-state", "open");
+  return dialog;
+};
+
+test.describe("search panel", () => {
+  test("opens from the header and focuses the input", async ({ page }) => {
+    await mockAlgolia(page);
+    await page.goto("/");
+
+    const dialog = await openPanel(page);
+    const input = dialog.locator("[data-search-input]");
+    await expect(input).toBeFocused();
+    await expect(dialog.locator("[data-search-results]")).toBeHidden();
+  });
+
+  test("a query renders hits, the count and the pager", async ({ page }) => {
+    await mockAlgolia(page);
+    await page.goto("/");
+    const dialog = await openPanel(page);
+
+    await dialog.locator("[data-search-input]").fill(QUERY);
+
+    await expect(dialog.locator("[data-search-count]")).toHaveText(`${MOCK_HITS.length} results`);
+    await expect(dialog.locator(".index-hit-card")).toHaveCount(5);
+    await expect(dialog.locator("[data-search-pager]")).toBeVisible();
+
+    const firstCard = dialog.locator(".index-hit-card").first();
+    await expect(firstCard).toHaveAttribute("href", `/articles/${MOCK_HITS[0].objectID}`);
+    await expect(firstCard).toHaveAttribute("aria-label", `link: ${MOCK_HITS[0].title}`);
+    await expect(firstCard.locator(".hit-title")).toContainText(MOCK_HITS[0].title);
+    await expect(firstCard.locator(".hit-tags")).toContainText(MOCK_HITS[0].tags.join(", "));
+  });
+
+  test("matches are highlighted", async ({ page }) => {
+    await mockAlgolia(page);
+    await page.goto("/");
+    const dialog = await openPanel(page);
+
+    await dialog.locator("[data-search-input]").fill("検索結果");
+    await expect(dialog.locator(".index-hit-card .hit-title mark").first()).toHaveText("検索結果");
+  });
+
+  test("keystrokes are debounced into a single request", async ({ page }) => {
+    const queries = await mockAlgolia(page);
+    await page.goto("/");
+    const dialog = await openPanel(page);
+
+    await dialog.locator("[data-search-input]").pressSequentially(QUERY, { delay: 30 });
+    await expect(dialog.locator(".index-hit-card").first()).toBeVisible();
+
+    expect(queries).toEqual([QUERY]);
+  });
+
+  test("the pager walks to the next page of hits", async ({ page }) => {
+    await mockAlgolia(page);
+    await page.goto("/");
+    const dialog = await openPanel(page);
+
+    await dialog.locator("[data-search-input]").fill(QUERY);
+    await expect(dialog.locator(".index-hit-card")).toHaveCount(5);
+
+    await dialog.locator('[data-search-pager] button[aria-label="Go to page 2"]').click();
+
+    await expect(
+      dialog.locator('[data-search-pager] button[aria-label="Go to page 2"]')
+    ).toHaveAttribute("aria-current", "page");
+    await expect(dialog.locator(".index-hit-card").first()).toHaveAttribute(
+      "href",
+      `/articles/${MOCK_HITS[5].objectID}`
+    );
+    await expect(page).toHaveURL(/[?&]page=2/);
+  });
+
+  test("the query is written onto the url and restored from it", async ({ page }) => {
+    await mockAlgolia(page);
+    await page.goto("/");
+    const dialog = await openPanel(page);
+    const entriesBefore = await page.evaluate(() => history.length);
+
+    await dialog.locator("[data-search-input]").fill(QUERY);
+    await expect(dialog.locator(".index-hit-card").first()).toBeVisible();
+    await expect(page).toHaveURL(new RegExp(`[?&]q=${QUERY}`));
+    // the panel is a modal over the page it was opened from: the url is rewritten
+    // with replaceState, so a search never buries the page under history entries
+    expect(await page.evaluate(() => history.length)).toBe(entriesBefore);
+
+    // a shared link opens the panel and re-runs the search on its own
+    await page.goto(`/?q=${QUERY}`);
+    const restored = searchDialog(page);
+    await expect(restored).toHaveAttribute("data-state", "open");
+    await expect(restored.locator("[data-search-input]")).toHaveValue(QUERY);
+    await expect(restored.locator(".index-hit-card")).toHaveCount(5);
+  });
+
+  test("a deep link to page 2 restores that page", async ({ page }) => {
+    await mockAlgolia(page);
+    await page.goto(`/?q=${QUERY}&page=2`);
+
+    const dialog = searchDialog(page);
+    await expect(dialog).toHaveAttribute("data-state", "open");
+    await expect(dialog.locator(".index-hit-card").first()).toHaveAttribute(
+      "href",
+      `/articles/${MOCK_HITS[5].objectID}`
+    );
+  });
+
+  test("clearing empties the results and the url", async ({ page }) => {
+    await mockAlgolia(page);
+    await page.goto("/");
+    const dialog = await openPanel(page);
+
+    const input = dialog.locator("[data-search-input]");
+    await input.fill(QUERY);
+    await expect(dialog.locator(".index-hit-card").first()).toBeVisible();
+
+    await dialog.locator("[data-search-clear]").click();
+    await expect(input).toHaveValue("");
+    await expect(input).toBeFocused();
+    await expect(dialog.locator("[data-search-results]")).toBeHidden();
+    await expect(page).not.toHaveURL(/[?&]q=/);
+  });
+
+  test("closing the panel drops the search from the url", async ({ page }) => {
+    await mockAlgolia(page);
+    await page.goto("/");
+    const dialog = await openPanel(page);
+    await dialog.locator("[data-search-input]").fill(QUERY);
+    await expect(page).toHaveURL(/[?&]q=/);
+
+    await page.keyboard.press("Escape");
+    await expect(dialog).toHaveAttribute("data-state", "closed");
+    await expect(page).not.toHaveURL(/[?&]q=/);
+  });
+
+  test("a query with no matches says so", async ({ page }) => {
+    await mockAlgolia(page);
+    await page.goto("/");
+    const dialog = await openPanel(page);
+
+    await dialog.locator("[data-search-input]").fill(EMPTY_QUERY);
+    await expect(dialog.locator("[data-search-status]")).toHaveText(
+      "No articles matched your search."
+    );
+    await expect(dialog.locator(".index-hit-card")).toHaveCount(0);
+  });
+
+  test("a failing backend surfaces an error instead of an empty panel", async ({ page }) => {
+    await mockAlgolia(page, { mode: "error" });
+    await page.goto("/");
+    const dialog = await openPanel(page);
+
+    await dialog.locator("[data-search-input]").fill(QUERY);
+    await expect(dialog.locator("[data-search-status]")).toHaveText(
+      "Search failed. Please try again."
+    );
+  });
+
+  test("a hit links to its article", async ({ page }) => {
+    await mockAlgolia(page);
+    await page.goto("/");
+    const dialog = await openPanel(page);
+
+    await dialog.locator("[data-search-input]").fill(QUERY);
+    const hits = dialog.locator(".index-hit-card");
+    await expect(hits.first()).toBeVisible();
+
+    for (const [index, hit] of (await hits.all()).entries()) {
+      await expect(hit).toHaveAttribute("href", `/articles/${MOCK_HITS[index].objectID}`);
+    }
+  });
+});

--- a/e2e/tests/seo.spec.ts
+++ b/e2e/tests/seo.spec.ts
@@ -1,0 +1,102 @@
+import { expect, test, type Page } from "../fixtures/test";
+
+const SITE_ORIGIN = "https://blog.miyamo.today";
+
+const metaContent = (page: Page, selector: string): Promise<string | null> =>
+  page.locator(selector).getAttribute("content");
+
+/** every page emits one <script type="application/ld+json"> holding one @graph */
+const jsonLdGraph = async (page: Page): Promise<Record<string, unknown>[]> => {
+  const scripts = page.locator('script[type="application/ld+json"]');
+  await expect(scripts).toHaveCount(1);
+  const parsed = JSON.parse((await scripts.textContent()) ?? "{}");
+  expect(parsed["@context"]).toContain("schema.org");
+  expect(Array.isArray(parsed["@graph"])).toBe(true);
+  return parsed["@graph"];
+};
+
+const typesOf = (graph: Record<string, unknown>[]): string[] =>
+  graph.flatMap((node) => {
+    const type = node["@type"];
+    return Array.isArray(type) ? (type as string[]) : [type as string];
+  });
+
+test.describe("head metadata @desktop", () => {
+  for (const [path, title] of [
+    ["/", "Articles | blog.miyamo.today"],
+    ["/tags", "Tags | blog.miyamo.today"],
+    ["/about", "About | blog.miyamo.today"],
+  ] as const) {
+    test(`${path} carries its title, canonical and open graph tags`, async ({ page }) => {
+      await page.goto(path);
+
+      await expect(page).toHaveTitle(title);
+      await expect(page.locator('meta[name="description"]')).toHaveAttribute(
+        "content",
+        /.+/
+      );
+
+      const canonical = await page.locator('link[rel="canonical"]').getAttribute("href");
+      expect(canonical).toBeTruthy();
+      const canonicalUrl = new URL(canonical!);
+      expect(canonicalUrl.origin).toBe(SITE_ORIGIN);
+      expect(canonicalUrl.pathname.replace(/\/$/, "")).toBe(path.replace(/\/$/, ""));
+
+      expect(await metaContent(page, 'meta[property="og:title"]')).toBe(title);
+      expect(await metaContent(page, 'meta[property="og:url"]')).toBe(canonical);
+      expect(await metaContent(page, 'meta[property="og:image"]')).toMatch(
+        new RegExp(`^${SITE_ORIGIN}/`)
+      );
+      expect(await metaContent(page, 'meta[name="twitter:card"]')).toBe("summary_large_image");
+      expect(await metaContent(page, 'meta[name="twitter:creator"]')).toBe("@miyamo2_jp");
+      expect(await metaContent(page, 'meta[property="fb:app_id"]')).toBe("000000000000000");
+    });
+  }
+
+  test("an article page describes itself as an article", async ({ page, articleIds }) => {
+    await page.goto(`/articles/${articleIds[0]}`);
+
+    const heading = (await page.getByRole("heading", { level: 1 }).innerText()).trim();
+    await expect(page).toHaveTitle(`${heading} | blog.miyamo.today`);
+
+    const canonical = await page.locator('link[rel="canonical"]').getAttribute("href");
+    expect(canonical).toBe(`${SITE_ORIGIN}/articles/${articleIds[0]}`);
+
+    const graph = await jsonLdGraph(page);
+    expect(typesOf(graph).join(" ")).toMatch(/Article|BlogPosting/);
+    expect(typesOf(graph)).toContain("BreadcrumbList");
+  });
+
+  test("the article list is a CollectionPage and a Blog", async ({ page }) => {
+    await page.goto("/");
+    const types = typesOf(await jsonLdGraph(page));
+    expect(types).toContain("CollectionPage");
+    expect(types).toContain("Blog");
+    expect(types).toContain("WebSite");
+    expect(types).toContain("Person");
+  });
+
+  test("the about page is a ProfilePage", async ({ page }) => {
+    await page.goto("/about");
+    expect(typesOf(await jsonLdGraph(page))).toContain("ProfilePage");
+  });
+
+  test("the search panel's url variant still points home", async ({ page }) => {
+    await page.goto("/?q=whatever");
+    const canonical = await page.locator('link[rel="canonical"]').getAttribute("href");
+    expect(new URL(canonical!).search).toBe("");
+  });
+
+  test("the fonts the pages preload are actually served", async ({ page, request }) => {
+    await page.goto("/");
+    const hrefs = await page
+      .locator('link[rel="preload"][as="font"]')
+      .evaluateAll((links) => links.map((link) => link.getAttribute("href") ?? ""));
+    expect(hrefs.length).toBeGreaterThan(0);
+
+    for (const href of hrefs) {
+      const response = await request.get(href);
+      expect(response.status(), `${href} should be served`).toBe(200);
+    }
+  });
+});

--- a/e2e/tests/tags.spec.ts
+++ b/e2e/tests/tags.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test, type Page } from "../fixtures/test";
+
+const PER_PAGE = 2;
+
+interface TagEntry {
+  href: string;
+  name: string;
+  count: number;
+}
+
+/** reads the tag list off /tags rather than restating what the mock serves */
+const readTags = async (page: Page): Promise<TagEntry[]> => {
+  const badges = page.locator('main a[href^="/tags/"]');
+  const entries: TagEntry[] = [];
+  for (const badge of await badges.all()) {
+    const href = (await badge.getAttribute("href")) ?? "";
+    const text = (await badge.innerText()).trim();
+    const match = /^#(.+)\((\d+)\)$/.exec(text);
+    if (!match) continue;
+    entries.push({ href, name: match[1], count: Number(match[2]) });
+  }
+  return entries;
+};
+
+test.describe("tags page (/tags)", () => {
+  test("lists every tag with its article count", async ({ page }) => {
+    await page.goto("/tags");
+    await expect(page.getByRole("heading", { level: 1, name: "Tags" })).toBeVisible();
+
+    const tags = await readTags(page);
+    expect(tags.length).toBeGreaterThan(0);
+    for (const tag of tags) {
+      expect(tag.count).toBeGreaterThan(0);
+      expect(tag.href).toMatch(/^\/tags\/[^/]+$/);
+    }
+  });
+
+  test("a tag opens its article list", async ({ page }) => {
+    await page.goto("/tags");
+    const [first] = await readTags(page);
+
+    await page.locator(`main a[href="${first.href}"]`).click();
+    await expect(page).toHaveURL(new RegExp(`${first.href}$`));
+    await expect(page.getByRole("heading", { level: 1 })).toHaveText(`#${first.name}`);
+    await expect(page.locator(".article-card")).toHaveCount(Math.min(first.count, PER_PAGE));
+  });
+});
+
+test.describe("tagged article list", () => {
+  test("a tag with more articles than fit on a page is paginated", async ({ page }) => {
+    await page.goto("/tags");
+    const paginated = (await readTags(page)).find((tag) => tag.count > PER_PAGE);
+    test.skip(!paginated, "no tag has more than one page of articles");
+
+    await page.goto(paginated!.href);
+    const firstPageTitles = await page.locator("a.article-card-link").allInnerTexts();
+
+    await page.getByLabel("Go to next page").click();
+    await expect(page).toHaveURL(new RegExp(`${paginated!.href}/2$`));
+    await expect(page.getByRole("heading", { level: 1 })).toHaveText(`#${paginated!.name}`);
+    expect(await page.locator("a.article-card-link").allInnerTexts()).not.toEqual(firstPageTitles);
+  });
+
+  test("page 1 of a tag redirects to the tag's own path", async ({ page }) => {
+    await page.goto("/tags");
+    const paginated = (await readTags(page)).find((tag) => tag.count > PER_PAGE);
+    test.skip(!paginated, "no tag has more than one page of articles");
+
+    await page.goto(`${paginated!.href}/1`);
+    await page.waitForURL((url) => url.pathname === paginated!.href);
+    await expect(page.getByRole("heading", { level: 1 })).toHaveText(`#${paginated!.name}`);
+  });
+
+  test("a tag that fits on one page shows no pager", async ({ page }) => {
+    await page.goto("/tags");
+    const single = (await readTags(page)).find((tag) => tag.count <= PER_PAGE);
+    test.skip(!single, "every tag spans more than one page");
+
+    await page.goto(single!.href);
+    await expect(page.locator("main").getByLabel("Go to next page")).toHaveCount(0);
+  });
+});

--- a/e2e/tests/theme.spec.ts
+++ b/e2e/tests/theme.spec.ts
@@ -1,0 +1,67 @@
+import { currentTheme, expect, test, themeToggle } from "../fixtures/test";
+
+test.describe("theme toggle", () => {
+  test("starts from the OS preference when nothing is stored", async ({ page }) => {
+    // the config pins colorScheme to light for every test
+    await page.goto("/");
+    expect(await currentTheme(page)).toBe("light");
+  });
+
+  test.describe("with a dark OS preference", () => {
+    test.use({ colorScheme: "dark" });
+
+    test("starts dark", async ({ page }) => {
+      await page.goto("/");
+      expect(await currentTheme(page)).toBe("dark");
+    });
+  });
+
+  test("toggling switches the theme and records the choice", async ({ page }) => {
+    await page.goto("/");
+    await themeToggle(page).click();
+
+    await expect(page.locator("html")).toHaveClass(/dark/);
+    expect(await currentTheme(page)).toBe("dark");
+    expect(await page.evaluate(() => localStorage.getItem("colorTheme"))).toBe("dark");
+
+    await themeToggle(page).click();
+    await expect(page.locator("html")).not.toHaveClass(/dark/);
+    expect(await page.evaluate(() => localStorage.getItem("colorTheme"))).toBe("light");
+  });
+
+  test("the choice survives a reload", async ({ page }) => {
+    await page.goto("/");
+    await themeToggle(page).click();
+    expect(await currentTheme(page)).toBe("dark");
+
+    await page.reload();
+    expect(await currentTheme(page)).toBe("dark");
+  });
+
+  test("the choice survives a client-router navigation", async ({ page }) => {
+    await page.goto("/");
+    await themeToggle(page).click();
+    expect(await currentTheme(page)).toBe("dark");
+
+    await page.locator("a.article-card-link").first().click();
+    await expect(page.locator("article .markdown-body")).toBeVisible();
+    expect(await currentTheme(page)).toBe("dark");
+  });
+
+  test("dark mode actually repaints the page", async ({ page }) => {
+    await page.goto("/");
+    const lightBackground = await page.evaluate(
+      // bg-background lives on #layout, not on <body>
+      () => getComputedStyle(document.getElementById("layout")!).backgroundColor
+    );
+
+    await themeToggle(page).click();
+    await expect(page.locator("html")).toHaveClass(/dark/);
+    const darkBackground = await page.evaluate(
+      // bg-background lives on #layout, not on <body>
+      () => getComputedStyle(document.getElementById("layout")!).backgroundColor
+    );
+
+    expect(darkBackground).not.toBe(lightBackground);
+  });
+});

--- a/e2e/tests/toc.spec.ts
+++ b/e2e/tests/toc.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "../fixtures/test";
+
+test.describe("table of contents", () => {
+  test.beforeEach(async ({ page, articleIds }) => {
+    await page.goto(`/articles/${articleIds[0]}`);
+  });
+
+  test("the sidebar lists every heading in the body @desktop", async ({ page }) => {
+    const toc = page.locator(".side-toc");
+    await expect(toc).toBeVisible();
+
+    const tocHrefs = await toc.locator('a[href^="#"]').evaluateAll((links) =>
+      links.map((link) => link.getAttribute("href") ?? "")
+    );
+    expect(tocHrefs.length).toBeGreaterThan(0);
+
+    const headingIds = await page
+      .locator("article .markdown-body :is(h1,h2,h3,h4,h5,h6)[id]")
+      .evaluateAll((headings) => headings.map((heading) => `#${heading.id}`));
+
+    // every entry points at a heading that exists on the page
+    for (const href of tocHrefs) {
+      expect(headingIds).toContain(decodeURIComponent(href));
+    }
+  });
+
+  test("clicking an entry scrolls to the heading and updates the hash @desktop", async ({
+    page,
+  }) => {
+    const entry = page.locator('.side-toc a[href^="#"]').nth(1);
+    const href = (await entry.getAttribute("href")) ?? "";
+
+    await entry.click();
+    // the hash is written with history.replaceState; the browser percent-encodes
+    // the japanese heading ids on the way into location.href
+    await expect.poll(() => decodeURIComponent(page.url())).toContain(href);
+
+    const id = decodeURIComponent(href.slice(1));
+    // smooth scrolling, so wait for the heading to settle inside the viewport
+    await expect(page.locator(`[id="${id}"]`)).toBeInViewport({ timeout: 10_000 });
+  });
+
+  test("the floating button opens the modal @mobile", async ({ page }) => {
+    const trigger = page.locator('button[aria-label="table-of-contents-button"]');
+    await expect(trigger).toBeVisible();
+
+    await trigger.click();
+    const dialog = page.locator("#toc-modal dialog");
+    await expect(dialog).toHaveAttribute("data-state", "open");
+    await expect(page.getByRole("heading", { name: "Table of Contents" })).toBeVisible();
+    expect(await dialog.locator('a[href^="#"]').count()).toBeGreaterThan(0);
+  });
+
+  test("picking a heading in the modal closes it and jumps there @mobile", async ({ page }) => {
+    await page.locator('button[aria-label="table-of-contents-button"]').click();
+    const dialog = page.locator("#toc-modal dialog");
+    await expect(dialog).toHaveAttribute("data-state", "open");
+
+    const entry = dialog.locator('a[href^="#"]').nth(1);
+    const href = (await entry.getAttribute("href")) ?? "";
+    await entry.click();
+
+    await expect(dialog).toHaveAttribute("data-state", "closed");
+    await expect.poll(() => decodeURIComponent(page.url())).toContain(href);
+    await expect(page.locator(`[id="${decodeURIComponent(href.slice(1))}"]`)).toBeInViewport({
+      timeout: 10_000,
+    });
+  });
+
+  test("the close button dismisses the modal @mobile", async ({ page }) => {
+    await page.locator('button[aria-label="table-of-contents-button"]').click();
+    const dialog = page.locator("#toc-modal dialog");
+    await expect(dialog).toHaveAttribute("data-state", "open");
+
+    await dialog.locator("button[data-dialog-close]").click();
+    await expect(dialog).toHaveAttribute("data-state", "closed");
+  });
+});

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["node"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "test-results", "playwright-report", "captures"]
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,15 @@
     "clean": "rm -rf dist .cache",
     "typecheck": "bunx astro sync && tsc --noEmit",
     "check": "bunx astro check",
-    "graphqlgen": "graphql-codegen generate"
+    "graphqlgen": "graphql-codegen generate",
+    "e2e": "node scripts/e2e.mjs",
+    "e2e:setup": "cd e2e && bun install && ./node_modules/.bin/playwright install --with-deps chromium",
+    "e2e:ui": "node scripts/e2e.mjs --ui",
+    "e2e:headed": "node scripts/e2e.mjs --headed",
+    "e2e:debug": "node scripts/e2e.mjs --debug",
+    "e2e:rerun": "node scripts/e2e.mjs --skip-build",
+    "e2e:report": "cd e2e && ./node_modules/.bin/playwright show-report",
+    "e2e:typecheck": "cd e2e && ./node_modules/.bin/tsc --noEmit"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.10",

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -1,0 +1,177 @@
+// End-to-end test runner.
+//
+//   node scripts/e2e.mjs [-- playwright args...]
+//
+// The suite runs against a *production build* served by `astro preview`, so what
+// it exercises is what gets deployed. Neither the blog API nor the GitHub API is
+// reachable from CI, so the build is pointed at scripts/mock-api.mjs -- the same
+// mock the build verification already uses.
+//
+// Responsibilities, in order:
+//   1. install the e2e workspace's own dependencies (e2e/package.json) if needed
+//   2. start the mock API and wait for it to answer
+//   3. build the site against the mock (skippable, see --skip-build)
+//   4. run playwright, which starts `astro preview` itself (see e2e/playwright.config.ts)
+//   5. stop the mock, whatever happened
+//
+// Environment:
+//   E2E_MOCK_PORT   port for scripts/mock-api.mjs           (default 8787)
+//   E2E_PORT        port `astro preview` is served on       (default 4321)
+//   E2E_SKIP_BUILD  "1" to reuse the dist/ already on disk  (same as --skip-build)
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const E2E_DIR = join(ROOT, "e2e");
+
+const MOCK_PORT = process.env.E2E_MOCK_PORT ?? "8787";
+const PREVIEW_PORT = process.env.E2E_PORT ?? "4321";
+const MOCK_ORIGIN = `http://localhost:${MOCK_PORT}`;
+const BASE_URL = `http://127.0.0.1:${PREVIEW_PORT}`;
+
+const args = process.argv.slice(2).filter((arg) => arg !== "--");
+const skipBuild = process.env.E2E_SKIP_BUILD === "1" || args.includes("--skip-build");
+const playwrightArgs = args.filter((arg) => arg !== "--skip-build");
+
+/**
+ * The build env. Every value is deterministic so a capture taken today matches
+ * the one taken tomorrow.
+ *
+ * ARTICLE_PER_PAGE is 2 against the mock's 4 articles: it is the only way the
+ * built site ends up with more than one list page, which is what makes the
+ * pager -- and /pages/2, /tags/Go/2 -- testable at all.
+ *
+ * The Algolia keys are fake on purpose. They only have to be non-empty for the
+ * search panel to build a client; every request it makes is intercepted in the
+ * browser (see e2e/fixtures/algolia.ts). ALGOLIA_ADMIN_KEY stays empty so the
+ * indexing integration has nothing to push to.
+ */
+const buildEnv = {
+  BLOG_API_MIYAMO_TODAY_URL: `${MOCK_ORIGIN}/graphql`,
+  BLOG_API_MIYAMO_TODAY_TOKEN: "e2e-token",
+  GITHUB_GRAPHQL_API_URL: `${MOCK_ORIGIN}/github`,
+  GITHUB_API_TOKEN: "e2e-token",
+  FACEBOOK_APP_ID: "000000000000000",
+  ARTICLE_PER_PAGE: "2",
+  PUBLIC_ALGOLIA_APP_ID: "E2EAPPID",
+  PUBLIC_ALGOLIA_SEARCH_KEY: "e2e-search-key",
+  PUBLIC_ALGOLIA_INDEX_NAME: "e2e-index",
+  ALGOLIA_ADMIN_KEY: "",
+  ALGOLIA_DRY_RUN: "true",
+  // recommendations need OpenAI + qdrant; content.config.ts skips them when unset
+  OPENAI_API_KEY: "",
+};
+
+const log = (message) => console.log(`\x1b[36m[e2e]\x1b[0m ${message}`);
+
+const run = (command, commandArgs, options = {}) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(command, commandArgs, {
+      stdio: "inherit",
+      cwd: ROOT,
+      ...options,
+      env: { ...process.env, ...options.env },
+    });
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      if (signal) {
+        reject(new Error(`${command} ${commandArgs.join(" ")} killed by ${signal}`));
+        return;
+      }
+      resolve(code ?? 0);
+    });
+  });
+
+const waitForMock = async (timeoutMs = 30_000) => {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${MOCK_ORIGIN}/img/e2e-health.png`);
+      if (response.ok) {
+        // drain the body so the socket is not left half-read
+        await response.arrayBuffer();
+        return;
+      }
+    } catch {
+      // not listening yet
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  throw new Error(`mock-api did not come up on ${MOCK_ORIGIN} within ${timeoutMs}ms`);
+};
+
+const installE2EDependencies = async () => {
+  if (existsSync(join(E2E_DIR, "node_modules", "@playwright", "test"))) {
+    return;
+  }
+  // e2e keeps its own package.json (like dev/mock-blogapi) so playwright never
+  // enters the site's dependency tree
+  log("installing e2e dependencies");
+  const code = await run("bun", ["install"], { cwd: E2E_DIR });
+  if (code !== 0) {
+    throw new Error(`bun install failed in ${E2E_DIR} (exit ${code})`);
+  }
+};
+
+let mock;
+
+const stopMock = () => {
+  if (mock && mock.exitCode === null) {
+    mock.kill("SIGTERM");
+  }
+};
+
+const main = async () => {
+  await installE2EDependencies();
+
+  log(`starting mock-api on ${MOCK_ORIGIN}`);
+  mock = spawn(process.execPath, [join(ROOT, "scripts", "mock-api.mjs")], {
+    cwd: ROOT,
+    stdio: ["ignore", "inherit", "inherit"],
+    env: { ...process.env, MOCK_API_PORT: MOCK_PORT },
+  });
+  mock.on("exit", (code) => {
+    if (code !== 0 && code !== null) {
+      console.error(`\x1b[31m[e2e]\x1b[0m mock-api exited with ${code}`);
+    }
+  });
+  await waitForMock();
+
+  if (skipBuild) {
+    log("skipping build (--skip-build); serving the existing dist/");
+  } else {
+    log("building the site against the mock API");
+    const code = await run("bunx", ["astro", "build"], { env: buildEnv });
+    if (code !== 0) {
+      throw new Error(`astro build failed (exit ${code})`);
+    }
+  }
+
+  log(`running playwright against ${BASE_URL}`);
+  return run(join(E2E_DIR, "node_modules", ".bin", "playwright"), ["test", ...playwrightArgs], {
+    cwd: E2E_DIR,
+    env: {
+      E2E_BASE_URL: BASE_URL,
+      E2E_PORT: PREVIEW_PORT,
+      E2E_ROOT: ROOT,
+    },
+  });
+};
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => {
+    stopMock();
+    process.exit(1);
+  });
+}
+
+try {
+  process.exitCode = await main();
+} catch (error) {
+  console.error(`\x1b[31m[e2e]\x1b[0m ${error instanceof Error ? error.message : error}`);
+  process.exitCode = 1;
+} finally {
+  stopMock();
+}

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -153,6 +153,10 @@ const main = async () => {
   return run(join(E2E_DIR, "node_modules", ".bin", "playwright"), ["test", ...playwrightArgs], {
     cwd: E2E_DIR,
     env: {
+      // `astro preview` re-runs the `astro:config:setup` hooks, so the loader
+      // integration validates its url/token there too -- the preview server
+      // (started by playwright's webServer) needs the same env the build got
+      ...buildEnv,
       E2E_BASE_URL: BASE_URL,
       E2E_PORT: PREVIEW_PORT,
       E2E_ROOT: ROOT,


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive Playwright end-to-end test suite for blog.miyamo.today. The suite runs against a production build served by `astro preview`, using `scripts/mock-api.mjs` to mock external APIs (blog API, GitHub GraphQL API), ensuring deterministic, reproducible tests without external dependencies.

## Key Changes

- **Test Infrastructure**
  - Added `e2e/` directory with Playwright configuration, fixtures, and test specs
  - Created `scripts/e2e.mjs` orchestrator that manages the full test pipeline: mock API startup → site build → Playwright execution
  - Implemented custom test fixtures (`capture`, `articleIds`) and request interception to block third-party requests

- **Test Coverage** (11 spec files)
  - Article list, pagination, and detail pages
  - Tag browsing and filtering
  - Search panel with Algolia mocking and debounce verification
  - Theme toggle persistence and OS preference detection
  - Table of contents navigation (desktop sidebar and mobile modal)
  - SEO metadata, feeds (RSS/sitemap), and 404 handling
  - Header navigation and client-side routing
  - Screenshot captures in light/dark themes at desktop (1440x900) and mobile (Pixel 7) viewports

- **Mock API & Build Configuration**
  - Mock API serves 4 articles (2 per page), 2 tags (Go, AWS), and OGP data
  - Build configured with deterministic environment variables (fake Algolia keys, no recommendations)
  - Algolia search intercepted in-browser with 12 mock hits across 3 pages

- **CI Integration**
  - Added `.github/workflows/e2e.yaml` for automated test runs on work branches
  - Artifacts include screenshot captures and HTML test report
  - Runs on ubuntu-24.04 with 30-minute timeout

- **Documentation**
  - Added `.claude/skills/e2e-authoring/SKILL.md` for writing/modifying tests
  - Added `.claude/skills/e2e-running/SKILL.md` for running tests and interpreting results
  - Added `e2e/README.md` with usage guide and coverage overview

- **Package Configuration**
  - Created `e2e/package.json` with Playwright as isolated dependency (not in site's tree)
  - Added npm scripts: `e2e`, `e2e:setup`, `e2e:rerun`, `e2e:ui`, `e2e:headed`, `e2e:debug`, `e2e:report`, `e2e:typecheck`

## Notable Implementation Details

- **Request Filtering**: Custom `page` fixture aborts third-party requests (CDN fonts, giscus, Buy Me a Coffee) while allowing localhost and data: URIs
- **Animation Freezing**: Tests disable CSS animations/transitions and caret visibility by default for stable captures
- **Screenshot Artifacts**: Deliberate captures saved to `e2e/captures/<project>/<name>.png` regardless of pass/fail, separate from Playwright's failure-only screenshots
- **Viewport Projects**: Tests tagged with `@desktop` or `@mobile` run on specific projects; untagged tests run on both
- **Article ID Discovery**: `articleIds` fixture reads from `/feed/rss.xml` to avoid hardcoding IDs
- **Algolia Mocking**: Intercepts Algolia requests in-browser with highlighting, pagination, and query tracking for debounce verification

https://claude.ai/code/session_01SJ3Ciah63mojNpCkf7XKNV