### PR TITLE
Simplify search panel management and improve hit card layout

### DIFF
--- a/e2e/fixtures/test.ts
+++ b/e2e/fixtures/test.ts
@@ -167,9 +167,16 @@ export const settle = async (page: Page): Promise<void> => {
 };
 
 /**
- * The header renders a mobile and a desktop copy of the search box and the theme
- * toggle; only one of the two is on screen at any width. Every helper below picks
- * the visible one.
+ * Narrows a locator to what is actually on screen.
+ *
+ * Several surfaces are rendered once per layout and hidden by breakpoint -- the
+ * share rail and the recommendations both exist twice on an article page -- so a
+ * plain selector matches copies a visitor cannot reach.
+ *
+ * The header is no longer one of them: it renders a single search box and a
+ * single theme toggle for every width. The helpers below keep the filter anyway,
+ * because a closed <dialog> is invisible too, which is what lets searchDialog()
+ * describe the panel only while it is open.
  */
 export const visible = (locator: Locator): Locator => locator.filter({ visible: true });
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -28,23 +28,29 @@ const navItems = [
       />
     </a>
   </div>
-  <div class="hidden h-full w-full justify-self-end pt-4 lg:block">
+  {/* One cluster for every breakpoint: the parts that belong to a single layout
+      hide themselves, and everything else is rendered exactly once. There used to
+      be two clusters, which meant a second copy of the whole search dialog sitting
+      in the DOM behind display:none -- and a panel script that had to work out
+      which of the two the URL and the keyboard belonged to. */}
+  <div class="h-full w-full justify-self-end">
     <div class="flex h-full items-center justify-end gap-2">
       {
         navItems.map((item) => (
-          <Button variant="ghost" size="sm" href={item.href} class="text-md font-bold">
+          <Button
+            variant="ghost"
+            size="sm"
+            href={item.href}
+            class="text-md hidden font-bold lg:inline-flex"
+          >
             <FaIcon icon={item.icon} />
             {item.label}
           </Button>
         ))
       }
-      <ThemeToggle variant="default" size="sm" ariaLabel="toggle-dark-mode" />
-      <Search />
-    </div>
-  </div>
-  <div class="h-full w-full justify-self-end pt-3 lg:hidden">
-    <div class="flex items-center justify-end gap-2">
-      <Search />
+      {/* below lg the search button leads the cluster; from lg it trails the theme
+          toggle, at the end of the nav -- the order each layout always had */}
+      <Search class="lg:order-1" />
       <ThemeToggle variant="default" size="sm" ariaLabel="toggle-dark-mode" />
       <Menu />
     </div>

--- a/src/components/search/Search.astro
+++ b/src/components/search/Search.astro
@@ -9,12 +9,23 @@ import "./Search.css";
  * Algolia search, previously react-instantsearch inside a Yamada UI modal.
  * The markup is static; `./search.ts` wires the querying and result rendering
  * and is fetched on demand (see the bootstrap script at the bottom).
- * This component is rendered twice by Header.astro (mobile / desktop), so every
- * hook below is scoped to the `.algolia-search` wrapper instead of an id.
+ * Header.astro renders exactly one of these for every breakpoint, so
+ * `.algolia-search` marks the single panel the script binds to.
  */
+
+interface Props {
+  /** merged into the dialog wrapper, which is a flex child of the header row */
+  class?: string;
+}
+
+// joined here rather than handed to Dialog as a class:list: on a component that
+// directive arrives as a prop of its own, which Dialog would spread onto a div
+// that already carries a class attribute
+const { class: className } = Astro.props;
+const wrapperClass = ["algolia-search", className].filter(Boolean).join(" ");
 ---
 
-<Dialog class="algolia-search">
+<Dialog class={wrapperClass}>
   <DialogTrigger
     aria-label="search"
     class="bg-background border-border hover:bg-muted focus-visible:ring-outline/50 inline-flex h-9 w-16 items-center justify-center rounded-3xl border text-sm font-bold transition-all outline-none focus-visible:ring-3 lg:text-base"
@@ -62,7 +73,8 @@ import "./Search.css";
       <div data-search-results hidden class="scrollable-y flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto">
         <p data-search-count class="text-muted-foreground text-right text-sm" hidden></p>
         <p data-search-status class="text-muted-foreground py-6 text-center text-sm" hidden></p>
-        <div data-search-hits class="flex flex-col gap-2"></div>
+        {/* the 1.5rem the recommendation rows are spaced by */}
+        <div data-search-hits class="flex flex-col gap-6"></div>
         <nav data-search-pager class="search-pager" aria-label="search result pages" hidden></nav>
         <a
           class="ais-PoweredBy"

--- a/src/components/search/Search.css
+++ b/src/components/search/Search.css
@@ -26,36 +26,36 @@
 
 /* ---------- hit cards ---------- */
 
+/* A hit is dressed as the row a recommendation is listed as (see Recommend.css):
+ * a 92px rounded square thumbnail on the left, the text beside it, no card edge
+ * of its own -- the rows are told apart by the gap between them. A hit carries
+ * one thing a recommendation does not, the matched snippet, so the text column
+ * is three lines (title / snippet / tags) rather than two.
+ *
+ * Every row is exactly as tall as its thumbnail whatever the hit holds, so the
+ * list never staggers as results come in: the title is clamped to two lines and
+ * the snippet and the tag line never wrap. */
 .index-hit-card {
   display: grid;
   grid-template-areas:
     "image title"
     "image content"
     "image tag";
-  grid-template-columns: 33% 1fr;
-  grid-template-rows: auto 1fr auto;
-  column-gap: 0.75rem;
-  min-height: 6rem;
+  grid-template-columns: 92px 1fr;
+  /* the tag line takes whatever the title and the snippet leave, and sits at the
+     bottom of it, level with the foot of the thumbnail */
+  grid-template-rows: auto auto 1fr;
+  column-gap: 1rem;
+  height: 92px;
   overflow: hidden;
-  isolation: isolate;
-  border-radius: var(--radius);
-  background-color: var(--card);
-  color: var(--card-foreground);
-  box-shadow:
-    0 4px 6px -1px rgb(0 0 0 / 0.1),
-    0 2px 4px -2px rgb(0 0 0 / 0.1);
+  color: inherit;
   text-decoration: none;
-}
-
-.index-hit-card:hover {
-  box-shadow:
-    0 10px 15px -3px rgb(0 0 0 / 0.1),
-    0 4px 6px -4px rgb(0 0 0 / 0.1);
 }
 
 .index-hit-card > .hit-image {
   grid-area: image;
   overflow: hidden;
+  border-radius: 0.5rem;
   background-color: var(--muted);
 }
 
@@ -65,34 +65,38 @@
   object-fit: cover;
 }
 
+/* two lines: three plus the snippet and the tags would not fit the 92px row */
 .index-hit-card > .hit-title {
   grid-area: title;
-  padding: 0.625rem 0.75rem 0 0;
-  font-size: 1.0625rem;
-  font-weight: 700;
-  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
   overflow: hidden;
+  font-size: 1.05rem;
+  font-weight: 700;
+  line-height: 1.5;
 }
 
 .index-hit-card > .hit-content {
   grid-area: content;
-  align-self: start;
-  padding-right: 0.75rem;
-  font-size: 0.875rem;
+  font-size: 0.8125rem;
+  line-height: 1.5;
   color: var(--muted-foreground);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
+/* one line that never wraps, so the row height cannot depend on the tag count */
 .index-hit-card > .hit-tags {
   grid-area: tag;
   align-self: end;
   display: flex;
   align-items: center;
   gap: 0.375rem;
-  padding: 0 0.75rem 0.625rem 0;
-  font-size: 0.8125rem;
+  font-size: 0.72rem;
+  line-height: 1.5;
   color: var(--muted-foreground);
   white-space: nowrap;
   overflow: hidden;

--- a/src/components/search/search.ts
+++ b/src/components/search/search.ts
@@ -273,13 +273,9 @@ class SearchPanel {
     // the starwind dialog exposes no open event, so follow the `open` attribute it toggles
     const observer = new MutationObserver(() => {
       if (this.dialog.open) {
-        activePanel = this;
         requestAnimationFrame(() => this.input.focus({ preventScroll: true }));
       } else {
-        // reset() drops the search state from the URL, so it still needs to be
-        // the active panel while it runs
         this.reset();
-        if (activePanel === this) activePanel = null;
       }
     });
     observer.observe(this.dialog, { attributes: true, attributeFilter: ["open"] });
@@ -294,15 +290,9 @@ class SearchPanel {
    */
   public adoptCurrentState(): void {
     if (!this.dialog.open) return;
-    activePanel = this;
     this.clearButton.hidden = this.input.value.length === 0;
     requestAnimationFrame(() => this.input.focus({ preventScroll: true }));
     if (this.input.value.trim() !== "") void this.search(true);
-  }
-
-  /** Header.astro renders a mobile and a desktop copy; only one of them is on screen */
-  public isVisible(): boolean {
-    return this.root.getClientRects().length > 0;
   }
 
   public isConnected(): boolean {
@@ -338,12 +328,7 @@ class SearchPanel {
     this.clearButton.hidden = route.query.length === 0;
     this.page = route.page;
 
-    if (!this.dialog.open) {
-      // the mutation observer only sees the attribute change a tick later, and
-      // the search below already wants to own the URL
-      activePanel = this;
-      this.requestOpen(0);
-    }
+    if (!this.dialog.open) this.requestOpen(0);
 
     if (route.query.trim() === "") {
       this.clearResults();
@@ -366,9 +351,8 @@ class SearchPanel {
     requestAnimationFrame(() => this.requestOpen(attempt + 1));
   }
 
-  /** the URL only ever follows the panel that is actually open */
   private syncRoute(state: RouteState | null): void {
-    if (activePanel !== this || this.navigatingAway) return;
+    if (this.navigatingAway) return;
     writeRoute(state);
   }
 
@@ -577,40 +561,29 @@ class SearchPanel {
   }
 }
 
-const initialized = new WeakSet<HTMLElement>();
-const panels: SearchPanel[] = [];
-/** the panel whose dialog is open, and therefore the one the URL belongs to */
-let activePanel: SearchPanel | null = null;
-
-/** the on-screen copy, falling back to the first one before any layout exists */
-const routedPanel = (): SearchPanel | null =>
-  activePanel ?? panels.find((panel) => panel.isVisible()) ?? panels[0] ?? null;
+/** the header's one search dialog, once it has been wired up */
+let panel: SearchPanel | null = null;
 
 const applyRoute = (force: boolean): void => {
-  routedPanel()?.applyRoute(readRoute(), force);
+  panel?.applyRoute(readRoute(), force);
 };
 
-const setupSearchPanels = (): void => {
-  // the header is transition:persist'ed, so these normally survive a swap; drop
-  // the ones that did not rather than routing a detached panel
-  for (let i = panels.length - 1; i >= 0; i--) {
-    if (!panels[i].isConnected()) panels.splice(i, 1);
-  }
-  if (activePanel && !activePanel.isConnected()) activePanel = null;
+const setupSearchPanel = (): void => {
+  // the header is transition:persist'ed, so the panel it holds normally survives
+  // a swap along with everything wired to it
+  if (panel?.isConnected()) return;
+  panel = null;
 
-  // Header.astro renders the component twice (mobile / desktop); one broken
-  // instance must not take the other one down with it
-  document.querySelectorAll<HTMLElement>(".algolia-search").forEach((root) => {
-    if (initialized.has(root)) return;
-    initialized.add(root);
-    try {
-      const panel = new SearchPanel(root);
-      panels.push(panel);
-      panel.adoptCurrentState();
-    } catch (error) {
-      console.error(error);
-    }
-  });
+  const root = document.querySelector<HTMLElement>(".algolia-search");
+  if (!root) return;
+  try {
+    panel = new SearchPanel(root);
+    panel.adoptCurrentState();
+  } catch (error) {
+    // a panel that cannot be wired up is left inert rather than taking the rest
+    // of the page's scripts down with it
+    console.error(error);
+  }
 };
 
 /**
@@ -644,7 +617,7 @@ document.addEventListener("astro:before-swap", (event) => {
   transitionFinished = viewTransition?.finished?.catch(() => undefined) ?? Promise.resolve();
 });
 
-setupSearchPanels();
+setupSearchPanel();
 applyRoute(false);
 
 /*
@@ -654,7 +627,7 @@ applyRoute(false);
  * before the swap it triggers.
  */
 document.addEventListener("astro:after-swap", () => {
-  setupSearchPanels();
+  setupSearchPanel();
   const id = navigationId;
   void transitionFinished.then(() => {
     if (id !== navigationId) return;

--- a/src/components/search/search.ts
+++ b/src/components/search/search.ts
@@ -31,7 +31,8 @@ interface HitDoc {
   thumbnail: string;
   _highlightResult?: {
     title?: { value: string };
-    tags?: { value: string }[];
+    /** one entry per tag, in the order the record lists them */
+    tags?: { value: string; matchLevel?: "none" | "partial" | "full" }[];
   };
   _snippetResult?: {
     content?: { value: string };
@@ -151,6 +152,32 @@ const setHighlighted = (target: HTMLElement, highlighted?: string, fallback?: st
   } else {
     target.textContent = fallback ?? "";
   }
+};
+
+/**
+ * The tag line for a hit: every tag the article carries, but with the ones the
+ * query actually matched moved to the front.
+ *
+ * The line is a single row that never wraps and is cut off at the end of the
+ * card, so without this a tag that explains the hit is exactly as likely to fall
+ * off that end as one that has nothing to do with the query. `tags` is a
+ * searchable attribute (see the index settings in astro.config.ts), so Algolia
+ * reports a per-tag matchLevel to sort on.
+ *
+ * Both groups keep the order the record lists them in, so tags that are equally
+ * relevant do not shuffle between queries.
+ *
+ * Returns the highlighted markup when the response carries it, and plain text to
+ * assign as textContent otherwise -- the two cannot be mixed, since only the
+ * former is Algolia-escaped.
+ */
+const tagLine = (hit: HitDoc): { html: string } | { text: string } => {
+  const highlighted = hit._highlightResult?.tags;
+  if (!highlighted) return { text: (hit.tags ?? []).join(", ") };
+
+  const matched = highlighted.filter((tag) => tag.matchLevel && tag.matchLevel !== "none");
+  const rest = highlighted.filter((tag) => !tag.matchLevel || tag.matchLevel === "none");
+  return { html: [...matched, ...rest].map((tag) => tag.value).join(", ") };
 };
 
 /** Thumbnails come from the index, so only let through URLs an <img> can safely load. */
@@ -456,11 +483,12 @@ class SearchPanel {
     tags.className = "hit-tags";
     tags.appendChild(faSvg(faTags));
     const tagList = document.createElement("span");
-    setHighlighted(
-      tagList,
-      hit._highlightResult?.tags?.map((tag) => tag.value).join(", "),
-      (hit.tags ?? []).join(", "),
-    );
+    const line = tagLine(hit);
+    if ("html" in line) {
+      tagList.innerHTML = line.html;
+    } else {
+      tagList.textContent = line.text;
+    }
     tags.appendChild(tagList);
 
     card.append(imageWrapper, title, content, tags);


### PR DESCRIPTION
## Summary
This PR refactors the search panel architecture to manage a single panel instance instead of multiple copies, and redesigns hit cards to match the recommendation row layout with improved spacing and tag prioritization.

## Key Changes

**Search Panel Management:**
- Removed multi-panel support that tracked mobile/desktop copies separately
- Simplified to manage a single `SearchPanel` instance that persists across navigation
- Eliminated `activePanel` tracking and `routedPanel()` logic that determined which panel owned the URL
- Removed `isVisible()` method and `initialized` WeakSet used for duplicate detection
- Renamed `setupSearchPanels()` to `setupSearchPanel()` to reflect single-instance model

**Hit Card Layout & Styling:**
- Redesigned cards from flexible layout to fixed 92px height matching recommendation rows
- Changed grid from percentage-based columns (`33% 1fr`) to fixed width (`92px 1fr`)
- Removed card styling (background, shadow, border-radius) to inherit from parent context
- Thumbnail now has rounded corners (`0.5rem`) instead of the card
- Title clamped to 2 lines using `-webkit-line-clamp`
- Snippet and tag line set to single-line with ellipsis (no wrapping)
- Adjusted spacing: column gap increased from `0.75rem` to `1rem`, row gap from `2px` to `6px`

**Tag Line Prioritization:**
- Added new `tagLine()` function that reorders tags to show matched tags first
- Leverages Algolia's per-tag `matchLevel` to identify which tags matched the query
- Maintains original order within each group (matched/unmatched) for consistency
- Handles both highlighted HTML and plain text fallback rendering

**Header Component Simplification:**
- Consolidated mobile/desktop search clusters into single cluster with responsive visibility
- Removed duplicate `<Search />` component rendering
- Applied responsive classes directly to nav items and search button
- Updated comments to reflect single-panel architecture

**Search Component Props:**
- Added `class` prop to `Search.astro` for responsive positioning
- Properly merges class with `.algolia-search` wrapper for layout flexibility

## Implementation Details
- The single panel instance survives `transition:persist` across page navigations
- Panel connectivity is checked on setup to handle stale references
- Error handling ensures a broken panel doesn't crash the page
- Tag reordering uses Algolia's native `matchLevel` field rather than custom matching logic
- Fixed card height prevents layout shift as results load

https://claude.ai/code/session_01BRavMjHn35xTXE7fAieuWJ