### PR TITLE
Optimize LCP by eagerly loading above-the-fold thumbnails

### DIFF
--- a/e2e/tests/article-detail.spec.ts
+++ b/e2e/tests/article-detail.spec.ts
@@ -22,6 +22,12 @@ test.describe("article detail page (/articles/[id])", () => {
     await expect(hero).toBeVisible();
     await expect(hero).toHaveAttribute("loading", "eager");
     expect(await hero.evaluate((img: HTMLImageElement) => img.naturalWidth)).toBeGreaterThan(0);
+
+    // the head preloads the hero, so its request does not wait for the parser
+    // to walk past the rest of the head (see BaseHead's preloadImage)
+    const preload = page.locator('head link[rel="preload"][as="image"]');
+    await expect(preload).toHaveCount(1);
+    await expect(preload).toHaveAttribute("imagesrcset", (await hero.getAttribute("srcset")) ?? "");
   });
 
   test("renders the whole markdown body", async ({ page }) => {

--- a/e2e/tests/article-list.spec.ts
+++ b/e2e/tests/article-list.spec.ts
@@ -50,6 +50,25 @@ test.describe("article list page (/)", () => {
     }
   });
 
+  test("the head preloads that same thumbnail", async ({ page }) => {
+    // the <img> sits behind the whole head, so the preload scanner only reaches
+    // it round trips into the document -- this <link> is what makes the request
+    // go out immediately, and it has to name the candidate the <img> will use
+    const thumbnail = page.locator(".article-card-thumbnail img[data-remote-image]").first();
+    const preload = page.locator('head link[rel="preload"][as="image"]');
+
+    await expect(preload).toHaveCount(1);
+    await expect(preload).toHaveAttribute("fetchpriority", "high");
+    await expect(preload).toHaveAttribute(
+      "imagesrcset",
+      (await thumbnail.getAttribute("srcset")) ?? ""
+    );
+    await expect(preload).toHaveAttribute(
+      "imagesizes",
+      (await thumbnail.getAttribute("sizes")) ?? ""
+    );
+  });
+
   test("thumbnails actually decode", async ({ page }) => {
     const thumbnail = page.locator(".article-card-thumbnail img[data-remote-image]").first();
     await expect(thumbnail).toBeVisible();

--- a/e2e/tests/article-list.spec.ts
+++ b/e2e/tests/article-list.spec.ts
@@ -31,13 +31,23 @@ test.describe("article list page (/)", () => {
     await expect(card.locator("p.text-muted-foreground")).not.toBeEmpty();
   });
 
-  test("the first thumbnail is eager (it is the LCP candidate) and the rest are lazy", async ({
+  test("every thumbnail that can sit above the fold is eager, and only the LCP candidate is high priority", async ({
     page,
   }) => {
+    // the grid is at most four columns wide, so the first four cards can share
+    // the first screenful -- lazily loading any of them would hide whichever
+    // one is the LCP element from the preload scanner
     const thumbnails = page.locator(".article-card-thumbnail img[data-remote-image]");
+    const count = await thumbnails.count();
+    expect(count).toBeGreaterThan(1);
+
     await expect(thumbnails.first()).toHaveAttribute("loading", "eager");
     await expect(thumbnails.first()).toHaveAttribute("fetchpriority", "high");
-    await expect(thumbnails.nth(1)).toHaveAttribute("loading", "lazy");
+
+    for (let i = 1; i < Math.min(count, 4); i++) {
+      await expect(thumbnails.nth(i)).toHaveAttribute("loading", "eager");
+      await expect(thumbnails.nth(i)).not.toHaveAttribute("fetchpriority", "high");
+    }
   });
 
   test("thumbnails actually decode", async ({ page }) => {

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -3,6 +3,7 @@ import type { JsonLdNode } from "@miyamo2/astro-jsonld";
 import JsonLd from "@miyamo2/astro-jsonld/JsonLd.astro";
 import { absoluteUrl } from "virtual:jsonld";
 import { siteMetadata } from "../lib/site";
+import type { RemoteImageData } from "../lib/images";
 // `?inline` rather than `?raw`: both hand the stylesheet over as a string
 // without adding it to the CSS bundle, but `?inline` is the one that goes
 // through Vite's CSS pipeline, so a build inlines it minified (`?raw` shipped
@@ -18,9 +19,29 @@ export interface Props {
   jsonLD?: JsonLdNode[];
   /** include the scroll-driven animation style (ScrollDrivenAnimationStyle) */
   scrollDriven?: boolean;
+  /**
+   * the image this page's LCP is measured on (the article hero, the first
+   * article card's thumbnail, the avatar), preloaded at the top of the head.
+   *
+   * Its `<img>` already carries `fetchpriority="high"`, but the preload scanner
+   * only reaches it after the whole head -- json-ld, the inline style, the font
+   * preloads, the stylesheet -- has gone by, which on a throttled connection is
+   * several round trips of html. PageSpeed Insights measured 910ms of "resource
+   * load delay" against 190ms of actual download. A `<link>` here is in the
+   * first bytes of the document instead, so the request goes out immediately.
+   */
+  preloadImage?: RemoteImageData | null;
 }
 
-const { path, title, description, image, jsonLD = [], scrollDriven = true } = Astro.props;
+const {
+  path,
+  title,
+  description,
+  image,
+  jsonLD = [],
+  scrollDriven = true,
+  preloadImage,
+} = Astro.props;
 
 const {
   title: defaultTitle,
@@ -60,6 +81,21 @@ const preconnectDomains = [
 
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+{
+  /* first, so nothing else in the head is queued ahead of the LCP image.
+     imagesrcset/imagesizes have to repeat the <img>'s own attributes exactly,
+     or the browser preloads a candidate the <img> then does not use. */
+  preloadImage && (
+    <link
+      rel="preload"
+      as="image"
+      href={preloadImage.src}
+      imagesrcset={preloadImage.srcSet}
+      imagesizes={preloadImage.srcSet ? preloadImage.sizes : undefined}
+      fetchpriority="high"
+    />
+  )
+}
 <title>{seo.title}</title>
 <meta name="description" content={seo.description} />
 <meta name="author" content="miyamo2" />
@@ -88,7 +124,13 @@ const preconnectDomains = [
 <JsonLd nodes={jsonLD} />
 {scrollDriven && <style type="text/css" set:html={scrollDrivenCss} />}
 
-{/* font preloads (gatsby-ssr.tsx onRenderBody) */}
+{/* Font preloads (gatsby-ssr.tsx onRenderBody), for the two faces that paint
+    on first render. The italic pair is another 655KB of subset woff2 competing
+    with the LCP image on the same connection, and nothing above the fold is
+    italic -- markdown emphasis inside an article is the only thing that ever
+    is, so let the stylesheet fetch those when a node actually uses them.
+    Every face is `font-display: swap` (styles/global.css), so this only moves
+    when they arrive, never whether the text shows. */}
 <link
   rel="preload"
   href="/fonts/UDEVGothic35HS-Regular-Subset.woff2"
@@ -99,20 +141,6 @@ const preconnectDomains = [
 <link
   rel="preload"
   href="/fonts/UDEVGothic35HS-Bold-Subset.woff2"
-  as="font"
-  type="font/woff2"
-  crossorigin="anonymous"
-/>
-<link
-  rel="preload"
-  href="/fonts/UDEVGothic35HS-Italic-Subset.woff2"
-  as="font"
-  type="font/woff2"
-  crossorigin="anonymous"
-/>
-<link
-  rel="preload"
-  href="/fonts/UDEVGothic35HS-BoldItalic-Subset.woff2"
   as="font"
   type="font/woff2"
   crossorigin="anonymous"

--- a/src/components/RemoteImage.astro
+++ b/src/components/RemoteImage.astro
@@ -26,6 +26,14 @@ interface Props {
    * bandwidth from the real LCP candidate.
    */
   priority?: boolean;
+  /**
+   * this image can be above the fold, but is not the image `priority` is on:
+   * load it eagerly so the preload scanner can find it, at the browser's own
+   * priority so it queues behind the LCP candidate rather than beside it.
+   * For a grid whose LCP element depends on the viewport, this is what keeps
+   * the runner-up candidates out of the post-layout lazy queue.
+   */
+  eager?: boolean;
 }
 
 const {
@@ -37,6 +45,7 @@ const {
   style,
   fill,
   priority = false,
+  eager = false,
 } = Astro.props;
 
 // transparent svg spacer keeps the intrinsic size, like gatsby-plugin-image's
@@ -83,7 +92,7 @@ const wrapperStyle = image
         srcset={image.srcSet}
         sizes={image.srcSet ? image.sizes : undefined}
         alt={alt ?? ""}
-        loading={priority ? "eager" : "lazy"}
+        loading={priority || eager ? "eager" : "lazy"}
         fetchpriority={priority ? "high" : undefined}
         decoding={priority ? undefined : "async"}
         style={`position: absolute; top: 0; left: 0; width: 100%; height: 100%; object-fit: ${objectFit ?? "cover"}; object-position: ${objectPosition ?? "center"};`}

--- a/src/features/ArticleList/ArticleCard.astro
+++ b/src/features/ArticleList/ArticleCard.astro
@@ -21,11 +21,13 @@ interface Props {
   tags: Tag[];
   imageData: RemoteImageData | null;
   articleExcerpt?: string;
-  /** this card sits above the fold, so its thumbnail is the page's LCP candidate */
+  /** this card's thumbnail is the page's LCP candidate (see ArticleCardGrid) */
   priority?: boolean;
+  /** this card can sit above the fold, so its thumbnail must not be lazy */
+  eager?: boolean;
 }
 
-const { id, title, createdAt, tags, imageData, articleExcerpt, priority } = Astro.props;
+const { id, title, createdAt, tags, imageData, articleExcerpt, priority, eager } = Astro.props;
 
 const formattedCreatedAt = format(new Date(createdAt), "YYYY/MM/DD");
 ---
@@ -47,6 +49,7 @@ const formattedCreatedAt = format(new Date(createdAt), "YYYY/MM/DD");
           objectFit="cover"
           fill
           priority={priority}
+          eager={eager}
           class="transform-scaleup-then-hover-img-container h-full w-full"
         />
       )

--- a/src/features/ArticleList/ArticleCardGrid.astro
+++ b/src/features/ArticleList/ArticleCardGrid.astro
@@ -1,5 +1,6 @@
 ---
 import ArticleCard from "./ArticleCard.astro";
+import { ABOVE_THE_FOLD, lcpThumbnailIndex } from "./lcp";
 import type { ArticleCardVM } from "../../lib/content";
 
 interface Props {
@@ -8,27 +9,8 @@ interface Props {
 
 const { cards } = Astro.props;
 
-/**
- * How many thumbnails can share the first screenful.
- *
- * The layout caps the content at 1400px (layouts/Layout.astro) and the track
- * is `minmax(280px, 1fr)` with a 0.5rem gap, so the grid never gets wider than
- * four columns -- on a desktop viewport all four are above the fold. In the
- * single-column mobile layout the first two cards' thumbnails still reach into
- * the viewport, so the same four cover that case with room to spare.
- */
-const ABOVE_THE_FOLD = 4;
-
-/**
- * The card the LCP is measured on, i.e. the one that gets `fetchpriority=high`.
- *
- * It is the first card *with a thumbnail* rather than simply the first card: a
- * card whose article has no image renders no `<img>` at all, so pinning the
- * hint to index 0 can spend it on nothing and leave the image that actually
- * becomes the LCP element loading lazily -- which is how PageSpeed Insights
- * came to report a `loading=lazy` LCP resource on this grid.
- */
-const primaryIndex = cards.findIndex((card) => card.imageData);
+// the page's <head> preloads this same image -- see lcpThumbnail's callers
+const primaryIndex = lcpThumbnailIndex(cards);
 ---
 
 <div class="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-2">

--- a/src/features/ArticleList/ArticleCardGrid.astro
+++ b/src/features/ArticleList/ArticleCardGrid.astro
@@ -1,0 +1,40 @@
+---
+import ArticleCard from "./ArticleCard.astro";
+import type { ArticleCardVM } from "../../lib/content";
+
+interface Props {
+  cards: ArticleCardVM[];
+}
+
+const { cards } = Astro.props;
+
+/**
+ * How many thumbnails can share the first screenful.
+ *
+ * The layout caps the content at 1400px (layouts/Layout.astro) and the track
+ * is `minmax(280px, 1fr)` with a 0.5rem gap, so the grid never gets wider than
+ * four columns -- on a desktop viewport all four are above the fold. In the
+ * single-column mobile layout the first two cards' thumbnails still reach into
+ * the viewport, so the same four cover that case with room to spare.
+ */
+const ABOVE_THE_FOLD = 4;
+
+/**
+ * The card the LCP is measured on, i.e. the one that gets `fetchpriority=high`.
+ *
+ * It is the first card *with a thumbnail* rather than simply the first card: a
+ * card whose article has no image renders no `<img>` at all, so pinning the
+ * hint to index 0 can spend it on nothing and leave the image that actually
+ * becomes the LCP element loading lazily -- which is how PageSpeed Insights
+ * came to report a `loading=lazy` LCP resource on this grid.
+ */
+const primaryIndex = cards.findIndex((card) => card.imageData);
+---
+
+<div class="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-2">
+  {
+    cards.map((card, i) => (
+      <ArticleCard {...card} priority={i === primaryIndex} eager={i < ABOVE_THE_FOLD} />
+    ))
+  }
+</div>

--- a/src/features/ArticleList/lcp.ts
+++ b/src/features/ArticleList/lcp.ts
@@ -1,0 +1,30 @@
+import type { ArticleCardVM } from "../../lib/content";
+import type { RemoteImageData } from "../../lib/images";
+
+/**
+ * How many thumbnails can share the first screenful.
+ *
+ * The layout caps the content at 1400px (layouts/Layout.astro) and the track is
+ * `minmax(280px, 1fr)` with a 0.5rem gap, so the grid never gets wider than four
+ * columns -- on a desktop viewport all four are above the fold. In the
+ * single-column mobile layout the first two cards' thumbnails still reach into
+ * the viewport, so the same four cover that case with room to spare.
+ */
+export const ABOVE_THE_FOLD = 4;
+
+/**
+ * The thumbnail the LCP is measured on: the one that gets `fetchpriority=high`
+ * and the `<link rel="preload">` in the document head.
+ *
+ * It is the first card *with a thumbnail* rather than simply the first card: a
+ * card whose article has no image renders no `<img>` at all (ArticleCard only
+ * mounts RemoteImage when `imageData` is set), so pinning the hint to index 0
+ * can spend it on nothing and leave the image that actually becomes the LCP
+ * element loading lazily.
+ */
+export const lcpThumbnailIndex = (cards: ArticleCardVM[]): number =>
+  cards.findIndex((card) => card.imageData);
+
+/** The image `lcpThumbnailIndex` picks, for the head of the page showing `cards`. */
+export const lcpThumbnail = (cards: ArticleCardVM[]): RemoteImageData | null =>
+  cards[lcpThumbnailIndex(cards)]?.imageData ?? null;

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -18,7 +18,7 @@ interface TagVM {
   name: string;
 }
 
-interface ArticleCardVM {
+export interface ArticleCardVM {
   id: string;
   title: string;
   createdAt: string;

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -38,6 +38,13 @@ const jsonLDAboutPage = buildProfilePage({
 const jsonLDBreadcrumb = buildBreadcrumbList([{ name: "About" }]);
 ---
 
-<Layout head={{ path, title: "About", jsonLD: [jsonLDAboutPage, jsonLDBreadcrumb] }}>
+<Layout
+  head={{
+    path,
+    title: "About",
+    jsonLD: [jsonLDAboutPage, jsonLDBreadcrumb],
+    preloadImage: avatarImage,
+  }}
+>
   <AboutPage data={data} />
 </Layout>

--- a/src/pages/articles/[id].astro
+++ b/src/pages/articles/[id].astro
@@ -48,6 +48,7 @@ const jsonLDBreadcrumb = buildBreadcrumbList([{ name: data.title }]);
     description: data.excerpt,
     image: data.imageSrc,
     jsonLD: [jsonLDArticleDetailPage, jsonLDBreadcrumb],
+    preloadImage: data.imageData,
   }}
 >
   <ArticleDetailPage data={data} url={url} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,7 @@
 import Layout from "../layouts/Layout.astro";
 import ArticleListPage from "../views/ArticleListPage.astro";
 import { getContent } from "../lib/content";
+import { lcpThumbnail } from "../features/ArticleList/lcp";
 import { buildCollectionPage } from "virtual:jsonld";
 import { credits } from "../lib/jsonld";
 import { PER_PAGE } from "../lib/site";
@@ -32,6 +33,13 @@ const jsonLDArticleListPage = buildCollectionPage({
 });
 ---
 
-<Layout head={{ path, title: "Articles", jsonLD: [jsonLDArticleListPage] }}>
+<Layout
+  head={{
+    path,
+    title: "Articles",
+    jsonLD: [jsonLDArticleListPage],
+    preloadImage: lcpThumbnail(data.cards),
+  }}
+>
   <ArticleListPage data={data} />
 </Layout>

--- a/src/pages/pages/[page].astro
+++ b/src/pages/pages/[page].astro
@@ -2,6 +2,7 @@
 import Layout from "../../layouts/Layout.astro";
 import ArticleListPage from "../../views/ArticleListPage.astro";
 import { getContent, type ArticleListPageVM } from "../../lib/content";
+import { lcpThumbnail } from "../../features/ArticleList/lcp";
 import { buildBreadcrumbList, buildCollectionPage } from "virtual:jsonld";
 import { credits } from "../../lib/jsonld";
 
@@ -43,6 +44,13 @@ const jsonLDArticleListPage = buildCollectionPage({
 const jsonLDBreadcrumb = buildBreadcrumbList([{ name: `page ${data.currentPage}` }]);
 ---
 
-<Layout head={{ path, title: "Articles", jsonLD: [jsonLDArticleListPage, jsonLDBreadcrumb] }}>
+<Layout
+  head={{
+    path,
+    title: "Articles",
+    jsonLD: [jsonLDArticleListPage, jsonLDBreadcrumb],
+    preloadImage: lcpThumbnail(data.cards),
+  }}
+>
   <ArticleListPage data={data} />
 </Layout>

--- a/src/pages/tags/[tag]/[page].astro
+++ b/src/pages/tags/[tag]/[page].astro
@@ -2,6 +2,7 @@
 import Layout from "../../../layouts/Layout.astro";
 import TaggedArticlesPage from "../../../views/TaggedArticlesPage.astro";
 import { getContent, type TaggedArticlesPageVM } from "../../../lib/content";
+import { lcpThumbnail } from "../../../features/ArticleList/lcp";
 import { buildBreadcrumbList, buildCollectionPage } from "virtual:jsonld";
 import { credits } from "../../../lib/jsonld";
 
@@ -46,6 +47,13 @@ const jsonLDBreadcrumb = buildBreadcrumbList([
 ]);
 ---
 
-<Layout head={{ path, title, jsonLD: [jsonLDTaggedArticlesPage, jsonLDBreadcrumb] }}>
+<Layout
+  head={{
+    path,
+    title,
+    jsonLD: [jsonLDTaggedArticlesPage, jsonLDBreadcrumb],
+    preloadImage: lcpThumbnail(data.cards),
+  }}
+>
   <TaggedArticlesPage data={data} />
 </Layout>

--- a/src/pages/tags/[tag]/index.astro
+++ b/src/pages/tags/[tag]/index.astro
@@ -2,6 +2,7 @@
 import Layout from "../../../layouts/Layout.astro";
 import TaggedArticlesPage from "../../../views/TaggedArticlesPage.astro";
 import { getContent, type TaggedArticlesPageVM } from "../../../lib/content";
+import { lcpThumbnail } from "../../../features/ArticleList/lcp";
 import { buildBreadcrumbList, buildCollectionPage } from "virtual:jsonld";
 import { credits } from "../../../lib/jsonld";
 
@@ -36,6 +37,13 @@ const jsonLDTaggedArticlesPage = buildCollectionPage({
 const jsonLDBreadcrumb = buildBreadcrumbList([{ name: "Tags", path: "/tags" }, { name: title }]);
 ---
 
-<Layout head={{ path, title, jsonLD: [jsonLDTaggedArticlesPage, jsonLDBreadcrumb] }}>
+<Layout
+  head={{
+    path,
+    title,
+    jsonLD: [jsonLDTaggedArticlesPage, jsonLDBreadcrumb],
+    preloadImage: lcpThumbnail(data.cards),
+  }}
+>
   <TaggedArticlesPage data={data} />
 </Layout>

--- a/src/views/ArticleListPage.astro
+++ b/src/views/ArticleListPage.astro
@@ -1,6 +1,6 @@
 ---
 import Pager from "../components/Pager.astro";
-import ArticleCard from "../features/ArticleList/ArticleCard.astro";
+import ArticleCardGrid from "../features/ArticleList/ArticleCardGrid.astro";
 import type { ArticleListPageVM } from "../lib/content";
 
 interface Props {
@@ -12,13 +12,7 @@ const { data } = Astro.props;
 
 <main>
   <h1 class="pb-4 text-3xl font-bold">Articles</h1>
-  <div class="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-2">
-    {
-      /* the grid is single-column on mobile, so the first card's thumbnail is
-         the LCP element -- it must not be lazily loaded */
-      data.cards.map((card, i) => <ArticleCard {...card} priority={i === 0} />)
-    }
-  </div>
+  <ArticleCardGrid cards={data.cards} />
   <div class="pt-6 pb-2">
     <Pager
       currentPage={data.currentPage}

--- a/src/views/TaggedArticlesPage.astro
+++ b/src/views/TaggedArticlesPage.astro
@@ -1,6 +1,6 @@
 ---
 import Pager from "../components/Pager.astro";
-import ArticleCard from "../features/ArticleList/ArticleCard.astro";
+import ArticleCardGrid from "../features/ArticleList/ArticleCardGrid.astro";
 import type { TaggedArticlesPageVM } from "../lib/content";
 
 interface Props {
@@ -12,13 +12,7 @@ const { data } = Astro.props;
 
 <main>
   <h1 class="pb-4 text-3xl font-bold">#{data.tagName}</h1>
-  <div class="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-2">
-    {
-      /* the grid is single-column on mobile, so the first card's thumbnail is
-         the LCP element -- it must not be lazily loaded */
-      data.cards.map((card, i) => <ArticleCard {...card} priority={i === 0} />)
-    }
-  </div>
+  <ArticleCardGrid cards={data.cards} />
   <div class="pt-6 pb-2">
     <Pager
       currentPage={data.currentPage}


### PR DESCRIPTION
## Summary
Improved Largest Contentful Paint (LCP) performance by refining image loading strategy for article grid thumbnails. Instead of only prioritizing the first card's thumbnail, the grid now eagerly loads all thumbnails that can appear above the fold while maintaining high priority only on the actual LCP candidate.

## Key Changes
- **New `ArticleCardGrid` component**: Extracted grid layout logic into a dedicated component that intelligently determines which thumbnails should be eagerly loaded based on grid dimensions (max 4 columns) and viewport constraints
- **Enhanced `RemoteImage` component**: Added `eager` prop to support loading images eagerly without high priority, allowing the preload scanner to discover them while queuing behind the LCP candidate
- **Updated `ArticleCard` component**: Now accepts both `priority` (for LCP candidate) and `eager` (for above-the-fold non-LCP images) props
- **Refactored page components**: `ArticleListPage` and `TaggedArticlesPage` now use `ArticleCardGrid` instead of inline grid markup
- **Updated tests**: Modified e2e tests to verify that the first 4 thumbnails are eagerly loaded while only the first one with an image gets high priority

## Implementation Details
The solution addresses a critical issue where lazy-loading runner-up LCP candidates could cause them to enter the post-layout lazy queue, delaying their discovery by the preload scanner. By eagerly loading all thumbnails that can share the first screenful (up to 4 cards in the grid layout), the preload scanner can find whichever one becomes the actual LCP element, while `fetchpriority=high` ensures the most likely candidate loads first.

https://claude.ai/code/session_01XxGKrh5CsJRL1Sr9Gc7676