### PR TITLE
Add E2E capture screenshots to pull request comments

### DIFF
--- a/.claude/skills/e2e-running/SKILL.md
+++ b/.claude/skills/e2e-running/SKILL.md
@@ -102,11 +102,12 @@ view as a local run.
 
 The last step, `scripts/e2e-capture-report.mjs`, embeds the captures in a sticky
 comment on the pull request the pushed commit belongs to (and does nothing when
-there is none). The images are assets of the `e2e-captures` prerelease rather than
-files on a branch, so nobody's `git pull` carries them; see the "On a pull
-request" section of `e2e/README.md` for why the other options do not work.
+there is none). The images are pushed to `refs/e2e-captures/pr-<n>/<run>` — a ref
+outside `refs/heads/*`, so nobody's clone or pull carries them — and embedded by
+raw URL. See the "On a pull request" section of `e2e/README.md` for why the other
+options do not work, and for how to delete an old run's ref.
 `node scripts/e2e-capture-report.mjs --dry-run` prints the comment locally without
-uploading anything.
+pushing anything.
 
 If a job fails only in CI, reproduce it with a clean build locally
 (`bun run e2e`), and check the viewport: CI runs both projects, and a local

--- a/.claude/skills/e2e-running/SKILL.md
+++ b/.claude/skills/e2e-running/SKILL.md
@@ -100,6 +100,14 @@ screenshots) and **e2e-report** (the HTML report plus traces and videos). Downlo
 `e2e-report`, unzip it, and open `playwright-report/index.html` to get the same
 view as a local run.
 
+The last step, `scripts/e2e-capture-report.mjs`, embeds the captures in a sticky
+comment on the pull request the pushed commit belongs to (and does nothing when
+there is none). The images are assets of the `e2e-captures` prerelease rather than
+files on a branch, so nobody's `git pull` carries them; see the "On a pull
+request" section of `e2e/README.md` for why the other options do not work.
+`node scripts/e2e-capture-report.mjs --dry-run` prints the comment locally without
+uploading anything.
+
 If a job fails only in CI, reproduce it with a clean build locally
 (`bun run e2e`), and check the viewport: CI runs both projects, and a local
 `--project=desktop-chromium` habit hides mobile regressions.

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -15,8 +15,8 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  # contents: write is for the e2e-captures prerelease the captures are uploaded
-  # to; nothing here writes to a branch
+  # contents: write is for pushing the captures to refs/e2e-captures/*; nothing
+  # here writes to a branch, a tag or a release
   contents: write
   packages: read
   pull-requests: write

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -15,8 +15,11 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  # contents: write is for the e2e-captures prerelease the captures are uploaded
+  # to; nothing here writes to a branch
+  contents: write
   packages: read
+  pull-requests: write
 
 jobs:
   e2e:
@@ -44,6 +47,7 @@ jobs:
         run: bun run e2e:setup
 
       - name: Run e2e tests
+        id: e2e
         run: bun run e2e
 
       # kept whether the run passed or failed: the captures are the point, and a
@@ -67,3 +71,13 @@ jobs:
             e2e/test-results
           if-no-files-found: warn
           retention-days: 14
+
+      # an artifact is a zip behind a login, so it cannot be shown in a review;
+      # this puts the same screenshots in a comment on the pull request the push
+      # belongs to, and does nothing when the branch has no pull request
+      - name: Comment the captures on the pull request
+        if: ${{ always() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          E2E_RESULT: ${{ steps.e2e.outcome }}
+        run: node scripts/e2e-capture-report.mjs

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -64,16 +64,27 @@ request, one collapsed table per project.
 
 A comment can only show an image from a public http(s) URL: GitHub's sanitizer
 drops `data:` sources, and an artifact is a zip behind a login. So the captures
-are uploaded as assets of a single `e2e-captures` prerelease. That keeps them out
-of the object database — a branch would be fetched by every `git clone` and
-`git pull` of this repository — and out of the way of real releases. The asset
-name carries the run id, because GitHub caches comment images by URL and a re-run
-that reused a name would keep showing the old screenshot.
+are committed and pushed — but to `refs/e2e-captures/pr-<n>/<run>`, not to a
+branch. That ref is outside the default fetch refspec
+(`+refs/heads/*:refs/remotes/origin/*`), so no `git clone` or `git pull` of this
+repository ever carries a screenshot; it is also invisible in the branch list and
+costs no Releases section. The comment then embeds
+`raw.githubusercontent.com/<repo>/<commit>/<project>/<name>.png`, which resolves
+without the commit being reachable from any branch — the ref alone is what keeps
+the objects alive.
 
-Assets are dropped when the run's own pull request pushes again, and the next run
-after that deletes whatever belongs to a pull request that has since closed. The
-images in a merged pull request's comment therefore stop resolving; the artifact
-on the run is the copy that survives its 14 days.
+Nothing is ever deleted or rewritten, so a comment written months ago still
+shows its screenshots. To reclaim the space of a pull request that no longer
+matters:
+
+```sh
+git ls-remote origin 'refs/e2e-captures/*'
+git push origin :refs/e2e-captures/pr-42/12345678.1
+```
+
+The two rejected alternatives, for the record: a branch is fetched by everyone,
+and Git LFS keeps clones small but meters storage and bandwidth and does not give
+the quota back when the files are deleted.
 
 The comment appears from the first push after the pull request exists — the
 workflow is driven by `push`, so a pull request opened on an already-tested

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -55,6 +55,34 @@ Every file runs in two projects: `desktop-chromium` (1440x900) and
 into `captures/<project>/<name>.png`. They are attached to the HTML report and
 uploaded by CI as the `e2e-captures` artifact on every run, pass or fail.
 
+### On a pull request
+
+`scripts/e2e-capture-report.mjs` puts the same screenshots in a comment, so a
+change can be reviewed without downloading anything. It runs as the last step of
+the E2E workflow — pass or fail — and rewrites one sticky comment per pull
+request, one collapsed table per project.
+
+A comment can only show an image from a public http(s) URL: GitHub's sanitizer
+drops `data:` sources, and an artifact is a zip behind a login. So the captures
+are uploaded as assets of a single `e2e-captures` prerelease. That keeps them out
+of the object database — a branch would be fetched by every `git clone` and
+`git pull` of this repository — and out of the way of real releases. The asset
+name carries the run id, because GitHub caches comment images by URL and a re-run
+that reused a name would keep showing the old screenshot.
+
+Assets are dropped when the run's own pull request pushes again, and the next run
+after that deletes whatever belongs to a pull request that has since closed. The
+images in a merged pull request's comment therefore stop resolving; the artifact
+on the run is the copy that survives its 14 days.
+
+The comment appears from the first push after the pull request exists — the
+workflow is driven by `push`, so a pull request opened on an already-tested
+branch gets its comment on the next push.
+
+```sh
+node scripts/e2e-capture-report.mjs --dry-run  # print the comment, upload nothing
+```
+
 ## The build the tests see
 
 `scripts/e2e.mjs` builds with `ARTICLE_PER_PAGE=2` over the mock's 4 articles, so

--- a/scripts/e2e-capture-report.mjs
+++ b/scripts/e2e-capture-report.mjs
@@ -1,34 +1,53 @@
 // Publishes the e2e capture sweep to the pull request the current commit belongs to.
 //
-//   node scripts/e2e-capture-report.mjs
+//   node scripts/e2e-capture-report.mjs [--dry-run]
 //
-// Run from .github/workflows/e2e.yaml after the suite, pass or fail. It does
-// three things:
-//   1. uploads e2e/captures/**.png as assets of one long-lived prerelease
-//   2. rewrites a single sticky comment on the pull request that embeds them
-//   3. deletes the assets of pull requests that are no longer open
+// Run from .github/workflows/e2e.yaml after the suite, pass or fail. It commits
+// e2e/captures/ as an orphan commit, pushes it to a ref of its own, and rewrites
+// a single sticky comment on the pull request that embeds the screenshots from
+// raw.githubusercontent.com.
 //
-// Why a release and not a branch: a comment can only show an image from a public
-// http(s) URL -- GitHub's sanitizer drops `data:` sources, and an actions
-// artifact is a single zip that needs a login -- so the files have to live
-// somewhere fetchable. A branch would do it, but `git fetch` takes refs/heads/*
-// by default, so every clone and pull of this repository would carry every
-// screenshot ever taken. Release assets are outside the object database
-// entirely, so they cost a reader nothing.
+// Why a ref outside refs/heads/*
+// ------------------------------
+// A comment can only show an image from a public http(s) URL: GitHub's sanitizer
+// drops `data:` sources, and an actions artifact is a zip that needs a login. So
+// the files have to be fetchable, which leaves three places to put them, and this
+// is the only one that costs nothing:
+//
+//   a branch          `git fetch` takes refs/heads/* by default, so every clone
+//                     and pull of this repository would carry every screenshot
+//   Git LFS           keeps clones small, but storage and bandwidth are metered
+//                     and deleting the files does not give the quota back
+//   release assets    free and unmetered, but a repository with no releases grows
+//                     a Releases section that exists only to hold screenshots
+//
+// `refs/e2e-captures/*` is in none of those ways visible: not in the branch list,
+// not in the Releases tab, and not in the default fetch refspec
+// (`+refs/heads/*:refs/remotes/origin/*`), so nobody's clone or pull pays for it.
+// Verified: GITHUB_TOKEN with contents: write may push such a ref, and raw serves
+// a blob by commit sha without the commit being reachable from any branch.
+//
+// One ref per run, never rewritten, so a comment written months ago still resolves
+// -- the ref is what keeps the objects from being collected. To reclaim the space
+// of a pull request that no longer matters:
+//
+//   git ls-remote origin 'refs/e2e-captures/*'
+//   git push origin :refs/e2e-captures/pr-42/12345678.1
 //
 // Environment (all provided by Actions unless noted):
 //   GITHUB_TOKEN         needs contents: write and pull-requests: write
 //   GITHUB_REPOSITORY    owner/repo
 //   GITHUB_SHA           the commit the captures were taken from
-//   GITHUB_RUN_ID        makes each run's asset names unique -- see below
+//   GITHUB_RUN_ID        names the ref, with GITHUB_RUN_ATTEMPT
 //   GITHUB_RUN_NUMBER    shown in the comment
 //   E2E_RESULT           outcome of the test step: "success" | "failure"
-//   E2E_CAPTURE_RELEASE  tag holding the assets (default "e2e-captures")
 //
-// `--dry-run` uploads nothing and prints the comment it would have posted, which
-// is how the layout is checked against a local `bun run e2e` without a token.
+// `--dry-run` pushes nothing and prints the comment it would have posted, which is
+// how the layout is checked against a local `bun run e2e` without a token.
+import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
-import { readFile, readdir } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -38,15 +57,6 @@ const CAPTURE_DIR = process.env.E2E_CAPTURE_DIR ?? join(ROOT, "e2e", "captures")
 /** Identifies the comment this script owns, so a run updates it instead of adding one. */
 const MARKER = "<!-- e2e-captures -->";
 
-const TAG = process.env.E2E_CAPTURE_RELEASE ?? "e2e-captures";
-const RELEASE_NAME = "E2E captures";
-const RELEASE_BODY = [
-  "Screenshots taken by the E2E workflow and embedded in pull request comments.",
-  "",
-  "Not a version of anything -- the assets are replaced on every run and removed",
-  "once their pull request closes.",
-].join("\n");
-
 const dryRun = process.argv.slice(2).includes("--dry-run");
 
 const token = process.env.GITHUB_TOKEN;
@@ -54,13 +64,13 @@ const repository = process.env.GITHUB_REPOSITORY ?? "miyamo2/blog.miyamo.today";
 const sha = process.env.GITHUB_SHA ?? "0".repeat(40);
 const runId = process.env.GITHUB_RUN_ID ?? "local";
 const runNumber = process.env.GITHUB_RUN_NUMBER ?? runId;
-/** Re-running a workflow keeps the run id and bumps this, so both are in the name. */
+/** Re-running a workflow keeps the run id and bumps the attempt; the ref needs both. */
 const runKey = `${runId}.${process.env.GITHUB_RUN_ATTEMPT ?? "1"}`;
 const result = process.env.E2E_RESULT ?? "success";
 
 const serverUrl = process.env.GITHUB_SERVER_URL ?? "https://github.com";
 const apiUrl = process.env.GITHUB_API_URL ?? "https://api.github.com";
-const uploadUrl = process.env.GITHUB_UPLOAD_URL ?? "https://uploads.github.com";
+const rawUrl = process.env.GITHUB_RAW_URL ?? "https://raw.githubusercontent.com";
 
 /** Widest project first: the desktop shots are the ones worth opening first. */
 const PROJECT_ORDER = ["desktop-chromium", "mobile-chromium"];
@@ -68,32 +78,41 @@ const PROJECT_ORDER = ["desktop-chromium", "mobile-chromium"];
 const log = (message) => console.log(`\x1b[36m[e2e-report]\x1b[0m ${message}`);
 
 const api = async (path, options = {}) => {
-  const { body, method = "GET", headers = {}, base = apiUrl, raw } = options;
-  const url = path.startsWith("http") ? path : `${base}${path}`;
-  const response = await fetch(url, {
+  const { body, method = "GET" } = options;
+  const response = await fetch(path.startsWith("http") ? path : `${apiUrl}${path}`, {
     method,
     headers: {
       accept: "application/vnd.github+json",
       authorization: `Bearer ${token}`,
       "x-github-api-version": "2022-11-28",
-      ...(raw ? {} : body ? { "content-type": "application/json" } : {}),
-      ...headers,
+      ...(body ? { "content-type": "application/json" } : {}),
     },
-    body: raw ?? (body === undefined ? undefined : JSON.stringify(body)),
+    body: body === undefined ? undefined : JSON.stringify(body),
   });
   if (!response.ok) {
-    throw new Error(`${method} ${url} -> ${response.status} ${await response.text()}`);
+    throw new Error(`${method} ${path} -> ${response.status} ${await response.text()}`);
   }
   return response.status === 204 ? undefined : response.json();
 };
 
 /**
- * Retries the transient half of the API surface.
- *
- * Asset uploads are the only calls here that move megabytes, and they are the
- * only ones observed to drop; everything else is small enough that one attempt
- * is honest.
+ * Runs git, returning its stdout. The remote url carries the token, so nothing
+ * here echoes a command; Actions masks GITHUB_TOKEN in logs either way.
  */
+const git = (args, cwd) =>
+  new Promise((resolve, reject) => {
+    const child = spawn("git", args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => (stdout += chunk));
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+    child.on("error", reject);
+    child.on("exit", (code) =>
+      code === 0 ? resolve(stdout) : reject(new Error(`git ${args[0]} failed (${code}): ${stderr.trim()}`))
+    );
+  });
+
+/** Retries the one step that moves megabytes and can lose a connection. */
 const withRetry = async (label, attempt, attempts = 3) => {
   for (let n = 1; ; n++) {
     try {
@@ -112,90 +131,6 @@ const resolvePullRequest = async () => {
   return pulls.find((pull) => pull.state === "open") ?? pulls[0];
 };
 
-/**
- * The one release every run writes to, created on first use.
- *
- * `make_latest: false` keeps it off the repository's front page, and the
- * prerelease flag keeps it out of the "latest release" API for anyone reading
- * this repository for its actual releases.
- */
-const ensureRelease = async () => {
-  try {
-    return await api(`/repos/${repository}/releases/tags/${TAG}`);
-  } catch (error) {
-    if (!error.message.includes("-> 404")) throw error;
-  }
-  log(`creating the ${TAG} release`);
-  try {
-    return await api(`/repos/${repository}/releases`, {
-      method: "POST",
-      body: {
-        tag_name: TAG,
-        name: RELEASE_NAME,
-        body: RELEASE_BODY,
-        prerelease: true,
-        make_latest: "false",
-      },
-    });
-  } catch (error) {
-    // two pull requests can race for the first run; the loser reads what won
-    if (!error.message.includes("-> 422")) throw error;
-    return api(`/repos/${repository}/releases/tags/${TAG}`);
-  }
-};
-
-const listAssets = async (releaseId) => {
-  const assets = [];
-  for (let page = 1; ; page++) {
-    const batch = await api(
-      `/repos/${repository}/releases/${releaseId}/assets?per_page=100&page=${page}`
-    );
-    assets.push(...batch);
-    if (batch.length < 100) return assets;
-  }
-};
-
-/** `pr-12-4711-desktop-chromium-article-list-light.png` -> 12 */
-const assetPullNumber = (name) => {
-  const match = /^pr-(\d+)-/.exec(name);
-  return match ? Number(match[1]) : undefined;
-};
-
-const deleteAsset = (asset) =>
-  api(`/repos/${repository}/releases/assets/${asset.id}`, { method: "DELETE" });
-
-/**
- * Drops what the release no longer has to serve: this pull request's previous
- * run, and everything belonging to a pull request that has since closed.
- *
- * A closed pull request's comment loses its images, which is the intended
- * trade -- these are a review aid for an open change, not a record.
- */
-const pruneAssets = async (assets, currentNumber) => {
-  const states = new Map([[currentNumber, "open"]]);
-  const stale = [];
-
-  for (const asset of assets) {
-    const number = assetPullNumber(asset.name);
-    if (number === undefined) continue;
-    if (number === currentNumber) {
-      stale.push(asset);
-      continue;
-    }
-    if (!states.has(number)) {
-      const pull = await api(`/repos/${repository}/pulls/${number}`).catch(() => undefined);
-      states.set(number, pull?.state ?? "closed");
-    }
-    if (states.get(number) !== "open") stale.push(asset);
-  }
-
-  if (stale.length === 0) return;
-  log(`deleting ${stale.length} stale asset(s)`);
-  for (const asset of stale) {
-    await deleteAsset(asset).catch((error) => log(`could not delete ${asset.name}: ${error.message}`));
-  }
-};
-
 const collectCaptures = async () => {
   if (!existsSync(CAPTURE_DIR)) return [];
   const entries = await readdir(CAPTURE_DIR, { withFileTypes: true });
@@ -210,35 +145,38 @@ const collectCaptures = async () => {
     const index = PROJECT_ORDER.indexOf(name);
     return index === -1 ? PROJECT_ORDER.length : index;
   };
-  return projects.sort((a, b) => rank(a.project) - rank(b.project) || a.project.localeCompare(b.project));
+  return projects.sort(
+    (a, b) => rank(a.project) - rank(b.project) || a.project.localeCompare(b.project)
+  );
 };
 
 /**
- * Asset names are flat, so the project has to be part of the name -- and so does
- * the run: GitHub proxies comment images through camo, which caches by URL, and
- * a re-run that reused a name would keep showing the previous screenshot.
+ * Commits the captures in a scratch repository -- the checkout the workflow is
+ * standing in is never touched -- and pushes that single parentless commit to
+ * this run's own ref. Returns the commit the raw urls will point at.
  */
-const assetName = (pullNumber, project, file) => `pr-${pullNumber}-${runKey}-${project}-${file}`;
-
-const uploadCapture = async (releaseId, pullNumber, project, file) => {
-  const name = assetName(pullNumber, project, file);
-  if (dryRun) return `${serverUrl}/${repository}/releases/download/${TAG}/${name}`;
-  const body = await readFile(join(CAPTURE_DIR, project, file));
-  const asset = await withRetry(`upload ${name}`, async () => {
-    try {
-      return await api(
-        `/repos/${repository}/releases/${releaseId}/assets?name=${encodeURIComponent(name)}`,
-        { method: "POST", base: uploadUrl, headers: { "content-type": "image/png" }, raw: body }
-      );
-    } catch (error) {
-      // a retry after a response that was lost on the way back: the upload landed
-      if (!error.message.includes("-> 422")) throw error;
-      const existing = (await listAssets(releaseId)).find((candidate) => candidate.name === name);
-      if (!existing) throw error;
-      return existing;
+const publishCaptures = async (pullNumber, captures) => {
+  const work = await mkdtemp(join(tmpdir(), "e2e-captures-"));
+  for (const { project, files } of captures) {
+    await mkdir(join(work, project), { recursive: true });
+    for (const file of files) {
+      await copyFile(join(CAPTURE_DIR, project, file), join(work, project, file));
     }
-  });
-  return asset.browser_download_url;
+  }
+
+  await git(["init", "-q"], work);
+  await git(["config", "user.name", "github-actions[bot]"], work);
+  await git(["config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com"], work);
+  // the runner has no signing key, and a signature would mean nothing here anyway
+  await git(["config", "commit.gpgsign", "false"], work);
+  await git(["add", "-A"], work);
+  await git(["commit", "-q", "-m", `e2e captures for #${pullNumber} (run ${runKey})`], work);
+  await git(["remote", "add", "origin", `https://x-access-token:${token}@github.com/${repository}.git`], work);
+
+  const ref = `refs/e2e-captures/pr-${pullNumber}/${runKey}`;
+  await withRetry("push captures", () => git(["push", "origin", `HEAD:${ref}`], work));
+  log(`pushed ${ref}`);
+  return (await git(["rev-parse", "HEAD"], work)).trim();
 };
 
 /**
@@ -249,7 +187,9 @@ const uploadCapture = async (releaseId, pullNumber, project, file) => {
 const splitName = (file) => {
   const name = file.replace(/\.png$/, "");
   const match = /-(light|dark)$/.exec(name);
-  return match ? { screen: name.slice(0, -match[0].length), theme: match[1] } : { screen: name, theme: "light" };
+  return match
+    ? { screen: name.slice(0, -match[0].length), theme: match[1] }
+    : { screen: name, theme: "light" };
 };
 
 const table = (rows) => {
@@ -263,13 +203,12 @@ const table = (rows) => {
 
 const buildBody = (sections) => {
   const status = result === "success" ? "✅ passed" : "❌ failed";
-  const shortSha = sha?.slice(0, 7) ?? "unknown";
   const runLink = `${serverUrl}/${repository}/actions/runs/${runId}`;
   const lines = [
     MARKER,
     "### 📸 E2E captures",
     "",
-    `${status} · commit [\`${shortSha}\`](${serverUrl}/${repository}/commit/${sha}) · [run #${runNumber}](${runLink})`,
+    `${status} · commit [\`${sha.slice(0, 7)}\`](${serverUrl}/${repository}/commit/${sha}) · [run #${runNumber}](${runLink})`,
     "",
   ];
 
@@ -277,23 +216,23 @@ const buildBody = (sections) => {
     lines.push(
       `No captures were produced by this run — see [the logs](${runLink}) for what stopped it.`
     );
-  } else {
-    for (const section of sections) {
-      lines.push(
-        `<details>`,
-        `<summary><b>${section.project}</b> · ${section.rows.length} screens</summary>`,
-        "",
-        table(section.rows),
-        "",
-        `</details>`,
-        ""
-      );
-    }
-    lines.push(
-      `<sub>Hosted as assets of the [\`${TAG}\`](${serverUrl}/${repository}/releases/tag/${TAG}) prerelease, which later runs clean up once this pull request closes. The full set, plus traces and videos for anything that failed, is on [the run](${runLink}).</sub>`
-    );
+    return lines.join("\n");
   }
 
+  for (const section of sections) {
+    lines.push(
+      "<details>",
+      `<summary><b>${section.project}</b> · ${section.rows.length} screens</summary>`,
+      "",
+      table(section.rows),
+      "",
+      "</details>",
+      ""
+    );
+  }
+  lines.push(
+    `<sub>Kept on \`refs/e2e-captures/pr-*\`, which is outside the default fetch refspec — no clone or pull carries these. Traces and videos for anything that failed are on [the run](${runLink}).</sub>`
+  );
   return lines.join("\n");
 };
 
@@ -304,7 +243,10 @@ const upsertComment = async (pullNumber, body) => {
     );
     const mine = comments.find((comment) => comment.body?.startsWith(MARKER));
     if (mine) {
-      await api(`/repos/${repository}/issues/comments/${mine.id}`, { method: "PATCH", body: { body } });
+      await api(`/repos/${repository}/issues/comments/${mine.id}`, {
+        method: "PATCH",
+        body: { body },
+      });
       log(`updated comment ${mine.id}`);
       return;
     }
@@ -333,20 +275,22 @@ const main = async () => {
   }
 
   const captures = await collectCaptures();
-  const release = dryRun ? { id: 0 } : await ensureRelease();
-  if (!dryRun) await pruneAssets(await listAssets(release.id), pull.number);
+  const commit =
+    captures.length === 0
+      ? undefined
+      : dryRun
+        ? "0".repeat(40)
+        : await publishCaptures(pull.number, captures);
 
-  const sections = [];
-  for (const { project, files } of captures) {
+  const sections = captures.map(({ project, files }) => {
     const rows = new Map();
     for (const file of files) {
-      const url = await uploadCapture(release.id, pull.number, project, file);
       const { screen, theme } = splitName(file);
+      const url = `${rawUrl}/${repository}/${commit}/${project}/${file}`;
       rows.set(screen, { ...rows.get(screen), [theme]: url });
     }
-    log(dryRun ? `${files.length} capture(s) for ${project}` : `uploaded ${files.length} capture(s) for ${project}`);
-    sections.push({ project, rows: [...rows] });
-  }
+    return { project, rows: [...rows] };
+  });
 
   const body = buildBody(sections);
   if (dryRun) {

--- a/scripts/e2e-capture-report.mjs
+++ b/scripts/e2e-capture-report.mjs
@@ -201,7 +201,7 @@ const table = (rows) => {
   return lines.join("\n");
 };
 
-const buildBody = (sections) => {
+const buildBody = (sections, { taken, failure } = {}) => {
   const status = result === "success" ? "✅ passed" : "❌ failed";
   const runLink = `${serverUrl}/${repository}/actions/runs/${runId}`;
   const lines = [
@@ -213,8 +213,11 @@ const buildBody = (sections) => {
   ];
 
   if (sections.length === 0) {
+    // a comment is still worth writing: which of the two happened is the useful part
     lines.push(
-      `No captures were produced by this run — see [the logs](${runLink}) for what stopped it.`
+      failure
+        ? `${taken} captures were taken, but pushing them failed (\`${failure}\`). They are in the **e2e-captures** artifact on [the run](${runLink}).`
+        : `No captures were produced by this run — see [the logs](${runLink}) for what stopped it.`
     );
     return lines.join("\n");
   }
@@ -275,14 +278,26 @@ const main = async () => {
   }
 
   const captures = await collectCaptures();
-  const commit =
-    captures.length === 0
-      ? undefined
-      : dryRun
-        ? "0".repeat(40)
-        : await publishCaptures(pull.number, captures);
+  const taken = captures.reduce((total, { files }) => total + files.length, 0);
 
-  const sections = captures.map(({ project, files }) => {
+  let commit;
+  let failure;
+  if (captures.length > 0) {
+    if (dryRun) {
+      commit = "0".repeat(40);
+    } else {
+      try {
+        commit = await publishCaptures(pull.number, captures);
+      } catch (error) {
+        // the screenshots are still in the artifact, and saying so beats a red
+        // step with no comment at all
+        failure = error instanceof Error ? error.message : String(error);
+        log(`could not publish the captures: ${failure}`);
+      }
+    }
+  }
+
+  const sections = (commit ? captures : []).map(({ project, files }) => {
     const rows = new Map();
     for (const file of files) {
       const { screen, theme } = splitName(file);
@@ -292,7 +307,7 @@ const main = async () => {
     return { project, rows: [...rows] };
   });
 
-  const body = buildBody(sections);
+  const body = buildBody(sections, { taken, failure });
   if (dryRun) {
     console.log(`\n${body}\n`);
     return;

--- a/scripts/e2e-capture-report.mjs
+++ b/scripts/e2e-capture-report.mjs
@@ -1,0 +1,364 @@
+// Publishes the e2e capture sweep to the pull request the current commit belongs to.
+//
+//   node scripts/e2e-capture-report.mjs
+//
+// Run from .github/workflows/e2e.yaml after the suite, pass or fail. It does
+// three things:
+//   1. uploads e2e/captures/**.png as assets of one long-lived prerelease
+//   2. rewrites a single sticky comment on the pull request that embeds them
+//   3. deletes the assets of pull requests that are no longer open
+//
+// Why a release and not a branch: a comment can only show an image from a public
+// http(s) URL -- GitHub's sanitizer drops `data:` sources, and an actions
+// artifact is a single zip that needs a login -- so the files have to live
+// somewhere fetchable. A branch would do it, but `git fetch` takes refs/heads/*
+// by default, so every clone and pull of this repository would carry every
+// screenshot ever taken. Release assets are outside the object database
+// entirely, so they cost a reader nothing.
+//
+// Environment (all provided by Actions unless noted):
+//   GITHUB_TOKEN         needs contents: write and pull-requests: write
+//   GITHUB_REPOSITORY    owner/repo
+//   GITHUB_SHA           the commit the captures were taken from
+//   GITHUB_RUN_ID        makes each run's asset names unique -- see below
+//   GITHUB_RUN_NUMBER    shown in the comment
+//   E2E_RESULT           outcome of the test step: "success" | "failure"
+//   E2E_CAPTURE_RELEASE  tag holding the assets (default "e2e-captures")
+//
+// `--dry-run` uploads nothing and prints the comment it would have posted, which
+// is how the layout is checked against a local `bun run e2e` without a token.
+import { existsSync } from "node:fs";
+import { readFile, readdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const CAPTURE_DIR = process.env.E2E_CAPTURE_DIR ?? join(ROOT, "e2e", "captures");
+
+/** Identifies the comment this script owns, so a run updates it instead of adding one. */
+const MARKER = "<!-- e2e-captures -->";
+
+const TAG = process.env.E2E_CAPTURE_RELEASE ?? "e2e-captures";
+const RELEASE_NAME = "E2E captures";
+const RELEASE_BODY = [
+  "Screenshots taken by the E2E workflow and embedded in pull request comments.",
+  "",
+  "Not a version of anything -- the assets are replaced on every run and removed",
+  "once their pull request closes.",
+].join("\n");
+
+const dryRun = process.argv.slice(2).includes("--dry-run");
+
+const token = process.env.GITHUB_TOKEN;
+const repository = process.env.GITHUB_REPOSITORY ?? "miyamo2/blog.miyamo.today";
+const sha = process.env.GITHUB_SHA ?? "0".repeat(40);
+const runId = process.env.GITHUB_RUN_ID ?? "local";
+const runNumber = process.env.GITHUB_RUN_NUMBER ?? runId;
+/** Re-running a workflow keeps the run id and bumps this, so both are in the name. */
+const runKey = `${runId}.${process.env.GITHUB_RUN_ATTEMPT ?? "1"}`;
+const result = process.env.E2E_RESULT ?? "success";
+
+const serverUrl = process.env.GITHUB_SERVER_URL ?? "https://github.com";
+const apiUrl = process.env.GITHUB_API_URL ?? "https://api.github.com";
+const uploadUrl = process.env.GITHUB_UPLOAD_URL ?? "https://uploads.github.com";
+
+/** Widest project first: the desktop shots are the ones worth opening first. */
+const PROJECT_ORDER = ["desktop-chromium", "mobile-chromium"];
+
+const log = (message) => console.log(`\x1b[36m[e2e-report]\x1b[0m ${message}`);
+
+const api = async (path, options = {}) => {
+  const { body, method = "GET", headers = {}, base = apiUrl, raw } = options;
+  const url = path.startsWith("http") ? path : `${base}${path}`;
+  const response = await fetch(url, {
+    method,
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${token}`,
+      "x-github-api-version": "2022-11-28",
+      ...(raw ? {} : body ? { "content-type": "application/json" } : {}),
+      ...headers,
+    },
+    body: raw ?? (body === undefined ? undefined : JSON.stringify(body)),
+  });
+  if (!response.ok) {
+    throw new Error(`${method} ${url} -> ${response.status} ${await response.text()}`);
+  }
+  return response.status === 204 ? undefined : response.json();
+};
+
+/**
+ * Retries the transient half of the API surface.
+ *
+ * Asset uploads are the only calls here that move megabytes, and they are the
+ * only ones observed to drop; everything else is small enough that one attempt
+ * is honest.
+ */
+const withRetry = async (label, attempt, attempts = 3) => {
+  for (let n = 1; ; n++) {
+    try {
+      return await attempt();
+    } catch (error) {
+      if (n >= attempts) throw error;
+      log(`${label} failed (attempt ${n}/${attempts}), retrying: ${error.message}`);
+      await new Promise((resolve) => setTimeout(resolve, 2000 * n));
+    }
+  }
+};
+
+/** The pull request this push belongs to, or undefined when the branch has none. */
+const resolvePullRequest = async () => {
+  const pulls = await api(`/repos/${repository}/commits/${sha}/pulls`);
+  return pulls.find((pull) => pull.state === "open") ?? pulls[0];
+};
+
+/**
+ * The one release every run writes to, created on first use.
+ *
+ * `make_latest: false` keeps it off the repository's front page, and the
+ * prerelease flag keeps it out of the "latest release" API for anyone reading
+ * this repository for its actual releases.
+ */
+const ensureRelease = async () => {
+  try {
+    return await api(`/repos/${repository}/releases/tags/${TAG}`);
+  } catch (error) {
+    if (!error.message.includes("-> 404")) throw error;
+  }
+  log(`creating the ${TAG} release`);
+  try {
+    return await api(`/repos/${repository}/releases`, {
+      method: "POST",
+      body: {
+        tag_name: TAG,
+        name: RELEASE_NAME,
+        body: RELEASE_BODY,
+        prerelease: true,
+        make_latest: "false",
+      },
+    });
+  } catch (error) {
+    // two pull requests can race for the first run; the loser reads what won
+    if (!error.message.includes("-> 422")) throw error;
+    return api(`/repos/${repository}/releases/tags/${TAG}`);
+  }
+};
+
+const listAssets = async (releaseId) => {
+  const assets = [];
+  for (let page = 1; ; page++) {
+    const batch = await api(
+      `/repos/${repository}/releases/${releaseId}/assets?per_page=100&page=${page}`
+    );
+    assets.push(...batch);
+    if (batch.length < 100) return assets;
+  }
+};
+
+/** `pr-12-4711-desktop-chromium-article-list-light.png` -> 12 */
+const assetPullNumber = (name) => {
+  const match = /^pr-(\d+)-/.exec(name);
+  return match ? Number(match[1]) : undefined;
+};
+
+const deleteAsset = (asset) =>
+  api(`/repos/${repository}/releases/assets/${asset.id}`, { method: "DELETE" });
+
+/**
+ * Drops what the release no longer has to serve: this pull request's previous
+ * run, and everything belonging to a pull request that has since closed.
+ *
+ * A closed pull request's comment loses its images, which is the intended
+ * trade -- these are a review aid for an open change, not a record.
+ */
+const pruneAssets = async (assets, currentNumber) => {
+  const states = new Map([[currentNumber, "open"]]);
+  const stale = [];
+
+  for (const asset of assets) {
+    const number = assetPullNumber(asset.name);
+    if (number === undefined) continue;
+    if (number === currentNumber) {
+      stale.push(asset);
+      continue;
+    }
+    if (!states.has(number)) {
+      const pull = await api(`/repos/${repository}/pulls/${number}`).catch(() => undefined);
+      states.set(number, pull?.state ?? "closed");
+    }
+    if (states.get(number) !== "open") stale.push(asset);
+  }
+
+  if (stale.length === 0) return;
+  log(`deleting ${stale.length} stale asset(s)`);
+  for (const asset of stale) {
+    await deleteAsset(asset).catch((error) => log(`could not delete ${asset.name}: ${error.message}`));
+  }
+};
+
+const collectCaptures = async () => {
+  if (!existsSync(CAPTURE_DIR)) return [];
+  const entries = await readdir(CAPTURE_DIR, { withFileTypes: true });
+  const projects = [];
+  for (const entry of entries.filter((candidate) => candidate.isDirectory())) {
+    const files = (await readdir(join(CAPTURE_DIR, entry.name)))
+      .filter((file) => file.endsWith(".png"))
+      .sort();
+    if (files.length > 0) projects.push({ project: entry.name, files });
+  }
+  const rank = (name) => {
+    const index = PROJECT_ORDER.indexOf(name);
+    return index === -1 ? PROJECT_ORDER.length : index;
+  };
+  return projects.sort((a, b) => rank(a.project) - rank(b.project) || a.project.localeCompare(b.project));
+};
+
+/**
+ * Asset names are flat, so the project has to be part of the name -- and so does
+ * the run: GitHub proxies comment images through camo, which caches by URL, and
+ * a re-run that reused a name would keep showing the previous screenshot.
+ */
+const assetName = (pullNumber, project, file) => `pr-${pullNumber}-${runKey}-${project}-${file}`;
+
+const uploadCapture = async (releaseId, pullNumber, project, file) => {
+  const name = assetName(pullNumber, project, file);
+  if (dryRun) return `${serverUrl}/${repository}/releases/download/${TAG}/${name}`;
+  const body = await readFile(join(CAPTURE_DIR, project, file));
+  const asset = await withRetry(`upload ${name}`, async () => {
+    try {
+      return await api(
+        `/repos/${repository}/releases/${releaseId}/assets?name=${encodeURIComponent(name)}`,
+        { method: "POST", base: uploadUrl, headers: { "content-type": "image/png" }, raw: body }
+      );
+    } catch (error) {
+      // a retry after a response that was lost on the way back: the upload landed
+      if (!error.message.includes("-> 422")) throw error;
+      const existing = (await listAssets(releaseId)).find((candidate) => candidate.name === name);
+      if (!existing) throw error;
+      return existing;
+    }
+  });
+  return asset.browser_download_url;
+};
+
+/**
+ * Splits `article-list-light` into the screen and the theme it was taken in.
+ * The captures with no suffix (the modals, the article sidebar) are light-mode
+ * shots too -- no spec toggles the theme before taking them.
+ */
+const splitName = (file) => {
+  const name = file.replace(/\.png$/, "");
+  const match = /-(light|dark)$/.exec(name);
+  return match ? { screen: name.slice(0, -match[0].length), theme: match[1] } : { screen: name, theme: "light" };
+};
+
+const table = (rows) => {
+  const lines = ["| screen | light | dark |", "| --- | --- | --- |"];
+  for (const [screen, shots] of rows) {
+    const cell = (url) => (url ? `<img src="${url}" width="360">` : "—");
+    lines.push(`| \`${screen}\` | ${cell(shots.light)} | ${cell(shots.dark)} |`);
+  }
+  return lines.join("\n");
+};
+
+const buildBody = (sections) => {
+  const status = result === "success" ? "✅ passed" : "❌ failed";
+  const shortSha = sha?.slice(0, 7) ?? "unknown";
+  const runLink = `${serverUrl}/${repository}/actions/runs/${runId}`;
+  const lines = [
+    MARKER,
+    "### 📸 E2E captures",
+    "",
+    `${status} · commit [\`${shortSha}\`](${serverUrl}/${repository}/commit/${sha}) · [run #${runNumber}](${runLink})`,
+    "",
+  ];
+
+  if (sections.length === 0) {
+    lines.push(
+      `No captures were produced by this run — see [the logs](${runLink}) for what stopped it.`
+    );
+  } else {
+    for (const section of sections) {
+      lines.push(
+        `<details>`,
+        `<summary><b>${section.project}</b> · ${section.rows.length} screens</summary>`,
+        "",
+        table(section.rows),
+        "",
+        `</details>`,
+        ""
+      );
+    }
+    lines.push(
+      `<sub>Hosted as assets of the [\`${TAG}\`](${serverUrl}/${repository}/releases/tag/${TAG}) prerelease, which later runs clean up once this pull request closes. The full set, plus traces and videos for anything that failed, is on [the run](${runLink}).</sub>`
+    );
+  }
+
+  return lines.join("\n");
+};
+
+const upsertComment = async (pullNumber, body) => {
+  for (let page = 1; ; page++) {
+    const comments = await api(
+      `/repos/${repository}/issues/${pullNumber}/comments?per_page=100&page=${page}`
+    );
+    const mine = comments.find((comment) => comment.body?.startsWith(MARKER));
+    if (mine) {
+      await api(`/repos/${repository}/issues/comments/${mine.id}`, { method: "PATCH", body: { body } });
+      log(`updated comment ${mine.id}`);
+      return;
+    }
+    if (comments.length < 100) break;
+  }
+  await api(`/repos/${repository}/issues/${pullNumber}/comments`, { method: "POST", body: { body } });
+  log(`commented on #${pullNumber}`);
+};
+
+const main = async () => {
+  if (!dryRun) {
+    if (!token) throw new Error("GITHUB_TOKEN is required");
+    if (!process.env.GITHUB_REPOSITORY || !process.env.GITHUB_SHA) {
+      throw new Error("GITHUB_REPOSITORY and GITHUB_SHA are required");
+    }
+  }
+
+  const pull = dryRun ? { number: 0, state: "open" } : await resolvePullRequest();
+  if (!pull) {
+    log(`${sha.slice(0, 7)} belongs to no pull request; nothing to comment on`);
+    return;
+  }
+  if (pull.state !== "open") {
+    log(`#${pull.number} is ${pull.state}; leaving it alone`);
+    return;
+  }
+
+  const captures = await collectCaptures();
+  const release = dryRun ? { id: 0 } : await ensureRelease();
+  if (!dryRun) await pruneAssets(await listAssets(release.id), pull.number);
+
+  const sections = [];
+  for (const { project, files } of captures) {
+    const rows = new Map();
+    for (const file of files) {
+      const url = await uploadCapture(release.id, pull.number, project, file);
+      const { screen, theme } = splitName(file);
+      rows.set(screen, { ...rows.get(screen), [theme]: url });
+    }
+    log(dryRun ? `${files.length} capture(s) for ${project}` : `uploaded ${files.length} capture(s) for ${project}`);
+    sections.push({ project, rows: [...rows] });
+  }
+
+  const body = buildBody(sections);
+  if (dryRun) {
+    console.log(`\n${body}\n`);
+    return;
+  }
+  await upsertComment(pull.number, body);
+};
+
+try {
+  await main();
+} catch (error) {
+  console.error(`\x1b[31m[e2e-report]\x1b[0m ${error instanceof Error ? error.message : error}`);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary

This change adds automatic E2E screenshot reporting directly to pull request comments, making it easy to review visual changes without downloading artifacts.

## Key Changes

- **New script `scripts/e2e-capture-report.mjs`**: Publishes E2E capture screenshots to pull request comments by:
  - Collecting screenshots from `e2e/captures/` organized by project
  - Committing them to an orphan git commit
  - Pushing to `refs/e2e-captures/pr-<n>/<run>` (outside default fetch refspec, so clones aren't bloated)
  - Embedding images via raw.githubusercontent.com URLs in a sticky comment that updates on each run
  - Supporting `--dry-run` mode to preview the comment locally

- **Updated `.github/workflows/e2e.yaml`**:
  - Added `contents: write` and `pull-requests: write` permissions
  - Added final step to run the capture report script after tests complete (pass or fail)
  - Passes test outcome via `E2E_RESULT` environment variable

- **Updated documentation**:
  - `e2e/README.md`: Explains the comment feature, why `refs/e2e-captures/*` is used instead of branches/LFS/releases, and how to clean up old refs
  - `.claude/skills/e2e-running/SKILL.md`: Documents the new reporting feature and `--dry-run` usage

## Implementation Details

- Uses `refs/e2e-captures/pr-<n>/<run>` to store captures outside the default fetch refspec, keeping clones small while maintaining permanent URLs
- Creates one sticky comment per pull request that updates with each run, showing screenshots in collapsible tables organized by project
- Handles both open and closed pull requests appropriately
- Includes retry logic for the network-intensive push operation
- Properly masks the GitHub token in logs via Actions' built-in masking

https://claude.ai/code/session_017oRYDfN39Na5ZtmHNk7rEv