### PR TITLE
Refactor search dialog layout to be full-screen at all breakpoints

### DIFF
--- a/src/components/search/Search.astro
+++ b/src/components/search/Search.astro
@@ -34,17 +34,20 @@ const wrapperClass = ["algolia-search", className].filter(Boolean).join(" ");
   </DialogTrigger>
 
   {/* no display utility here: it would override the closed <dialog>'s ua display:none */}
-  {/* mobile-first: fills the screen below lg, then lg: restores the centered card */}
+  {/* fills the screen at every breakpoint; the panel's contents are held to a
+      readable column by the wrapper below rather than by the dialog's own width */}
   <DialogContent
-    class="search-dialog top-0 left-0 h-dvh max-h-none w-full max-w-none translate-x-0 translate-y-0 sm:top-0 sm:translate-y-0 rounded-none border-0 overflow-hidden p-4 lg:top-[10vh] lg:left-[50%] lg:h-auto lg:max-h-[80vh] lg:w-[92vw] lg:max-w-3xl lg:translate-x-[-50%] lg:rounded-lg lg:border"
+    class="search-dialog top-0 left-0 h-dvh max-h-none w-full max-w-none translate-x-0 translate-y-0 sm:top-0 sm:translate-y-0 rounded-none border-0 overflow-hidden p-4 lg:p-6"
     animationDuration={300}
   >
     <DialogHeader class="sr-only">
       <DialogTitle>Search articles</DialogTitle>
     </DialogHeader>
 
-    <div class="flex h-full min-h-0 flex-col gap-3">
-      <div class="relative pr-9">
+    <div class="mx-auto flex h-full w-full max-w-3xl min-h-0 flex-col gap-3">
+      {/* room for the dialog's close button, which overlaps the input row only
+          while the column is as wide as the panel */}
+      <div class="relative pr-9 lg:pr-0">
         <FaIcon
           icon={faSearch}
           class="text-muted-foreground pointer-events-none absolute top-1/2 left-3 -translate-y-1/2"

--- a/src/components/search/Search.css
+++ b/src/components/search/Search.css
@@ -16,11 +16,25 @@
   vertical-align: -0.125em;
 }
 
-/* line the dialog's built-in close button up with the search input:
-   the panel's 1rem padding plus half of the input's 2.75rem height */
+/* line the dialog's built-in close button up with the search input: the panel's
+   own padding plus half of the input's 2.75rem height. The panel is full screen
+   at every breakpoint, so the button sits in its corner rather than beside the
+   centred column of results. */
+.search-dialog {
+  --search-panel-padding: 1rem;
+}
+
+/* --breakpoint-lg, spelled out: this file is not processed by tailwind, so the
+   token is not available here */
+@media (min-width: 1200px) {
+  .search-dialog {
+    --search-panel-padding: 1.5rem;
+  }
+}
+
 .search-dialog > .starwind-dialog-close {
-  top: 2.375rem;
-  right: 1rem;
+  top: calc(var(--search-panel-padding) + 1.375rem);
+  right: var(--search-panel-padding);
   transform: translateY(-50%);
 }
 


### PR DESCRIPTION
## Summary
Refactored the search dialog to fill the screen at every breakpoint, with the results panel contents constrained to a readable column width via an inner wrapper rather than the dialog's own width constraints. This simplifies the responsive behavior and improves the positioning of the close button.

## Key Changes
- **CSS refactoring**: Introduced CSS custom properties (`--search-panel-padding`) to manage padding at different breakpoints (1rem on mobile, 1.5rem on lg+), making the close button positioning more maintainable
- **Dialog layout**: Removed all lg-specific positioning classes (top, left, transform, width, height, border, rounded) that previously centered the dialog as a card
- **Content wrapper**: Added an inner `max-w-3xl` centered div to constrain the search results to a readable column width while the dialog itself remains full-screen
- **Close button positioning**: Updated to use CSS custom properties for dynamic positioning based on padding, ensuring proper alignment at all breakpoints
- **Input padding**: Added responsive padding adjustment (`lg:pr-0`) to the search input row to account for the close button overlap only when the column is as wide as the panel

## Implementation Details
- The dialog now uses `h-dvh w-full` at all breakpoints instead of switching between full-screen and centered card layouts
- Padding is managed via CSS variables to keep the close button aligned with the input field across breakpoints
- The inner wrapper uses `mx-auto max-w-3xl` to center and constrain content width, separating layout concerns between the dialog container and content presentation
- Comments clarify that the panel is full-screen at every breakpoint, with the close button positioned in the corner rather than beside the centered column

https://claude.ai/code/session_018qAJn9qPdGpBtKqQzb7BYF